### PR TITLE
Update NuGet.config (add source to restore MAUI NuGet packages).

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -6,7 +6,6 @@
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="maui" value="https://aka.ms/maui-preview/index.json" />
     <add key="public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
-    <add key="MAUI preview" value="https://aka.ms/maui-preview/index.json" />
   </packageSources>
   <config>
     <add key="globalPackagesFolder" value="packages" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -5,7 +5,8 @@
     <!-- ensure only the sources defined below are used -->
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="xamarin" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json" />
-    <add key="public"  value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <add key="public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <add key="MAUI preview" value="https://aka.ms/maui-preview/index.json" />
   </packageSources>
   <config>
     <add key="globalPackagesFolder" value="packages" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,7 +4,7 @@
     <clear />
     <!-- ensure only the sources defined below are used -->
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
-    <add key="xamarin" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json" />
+    <add key="maui" value="https://aka.ms/maui-preview/index.json" />
     <add key="public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="MAUI preview" value="https://aka.ms/maui-preview/index.json" />
   </packageSources>


### PR DESCRIPTION
On .NET 6 preview 4 we need to add a source to restore MAUI NuGet packages.
We can do it running CLI commands:
```
dotnet new nugetconfig
dotnet nuget add source -n maui-preview https://aka.ms/maui-preview/index.json
```
Or adding the source on VS:

![image](https://user-images.githubusercontent.com/139274/120108415-519c7d80-c165-11eb-8ca5-c7e08fc90972.png)

I do prefer the second way beacause it works on any new MAUI project.
Alas it doesn't work if there is, as in the maui-samples repo, a NuGet.config file with a `<clear />` comand 😢

So I've created this PR adding the needed source  to the file itself.