### PR TITLE
Enable WinUI 3 builds in Azure DevOps

### DIFF
--- a/HelloMauiWinUI3/HelloMauiWinUI3 (Package)/Package.appxmanifest
+++ b/HelloMauiWinUI3/HelloMauiWinUI3 (Package)/Package.appxmanifest
@@ -38,7 +38,7 @@
         Square44x44Logo="Images\Square44x44Logo.png">
         <uap:DefaultTile Wide310x150Logo="Images\Wide310x150Logo.png"  Square71x71Logo="Images\SmallTile.png" Square310x310Logo="Images\LargeTile.png" ShortName="Hello MAUI"/>
         <uap:SplashScreen Image="Images\SplashScreen.png"  BackgroundColor="#512BD4"/>
-        <uap:LockScreen BadgeLogo="Images\BadgeLogo.png"/>
+        <uap:LockScreen BadgeLogo="Images\BadgeLogo.png" Notification="badgeAndTileText"/>
       </uap:VisualElements>
     </Application>
   </Applications>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,18 +42,17 @@ jobs:
       displayName: build samples
       errorActionPreference: stop
 
-    # TODO: enable these when VS 16.10 is available
-    # - task: MSBuild@1
-    #   displayName: build WinUI3 Debug
-    #   inputs:
-    #     solution: HelloMauiWinUI3/HelloMauiWinUI3.sln
-    #     msbuildArguments: -restore -p:Configuration=Debug -bl:$(LogDirectory)\WinUI3-Debug.binlog
+    - task: MSBuild@1
+      inputs:
+        solution: HelloMauiWinUI3/HelloMauiWinUI3.sln
+        msbuildArguments: -restore -p:Configuration=Debug -bl:$(Build.ArtifactStagingDirectory)\logs\WinUI3-Debug.binlog
+      displayName: build WinUI3 Debug
 
-    # - task: MSBuild@1
-    #   displayName: build WinUI3 Release
-    #   inputs:
-    #     solution: HelloMauiWinUI3/HelloMauiWinUI3.sln
-    #     msbuildArguments: -p:Configuration=Release -bl:$(LogDirectory)\WinUI3-Release.binlog
+    - task: MSBuild@1
+      inputs:
+        solution: HelloMauiWinUI3/HelloMauiWinUI3.sln
+        msbuildArguments: -p:Configuration=Release -bl:$(LogDirectory)\WinUI3-Release.binlog
+      displayName: build WinUI3 Release
 
     - task: CopyFiles@2
       displayName: copy artifacts


### PR DESCRIPTION
The Azure DevOps agents now have VS2019 16.10 installed, so the WinUI3 build step can be uncommented. Confirmation can be found here [https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#visual-studio-enterprise-2019](https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#visual-studio-enterprise-2019).