### PR TITLE
Updates for .NET 6 Preview 6

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,6 +7,11 @@
     <PublishTrimmed Condition=" '$(TargetFramework)' == 'net6.0-ios' or '$(TargetFramework)' == 'net6.0-macos' or '$(TargetFramework)' == 'net6.0-maccatalyst' ">false</PublishTrimmed>
   </PropertyGroup>
 
+  <!-- Temporarily disable runtimeconfig.json under .NET framework MSBuild -->
+  <PropertyGroup Condition=" '$(MSBuildRuntimeType)' == 'Full' and ('$(TargetFramework)' == 'net6.0-android' or '$(TargetFramework)' == 'net6.0-ios' or '$(TargetFramework)' == 'net6.0-maccatalyst') ">
+    <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
+  </PropertyGroup>
+
   <!-- Required - Overwrite tasks that are not needed when multitargeting -->
   <Target Name="ValidateWinUIPlatform" />
   <Target Name="BinPlaceBootstrapDll" />

--- a/HelloMaui/App.xaml.cs
+++ b/HelloMaui/App.xaml.cs
@@ -11,7 +11,7 @@ namespace HelloMaui
 			InitializeComponent();
 		}
 
-		protected override IWindow CreateWindow(IActivationState activationState)
+		protected override Window CreateWindow(IActivationState activationState)
 		{
 			Microsoft.Maui.Controls.Compatibility.Forms.Init(activationState);
 

--- a/HelloMaui/HelloMaui.csproj
+++ b/HelloMaui/HelloMaui.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0-ios;net6.0-android;net6.0-maccatalyst</TargetFrameworks>
     <OutputType>Exe</OutputType>
+    <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
     <ApplicationId>com.microsoft.hellomaui</ApplicationId>
     <ApplicationTitle>MAUI</ApplicationTitle>
@@ -11,9 +12,6 @@
     <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">maccatalyst-x64</RuntimeIdentifier>
     <InvariantGlobalization Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">true</InvariantGlobalization>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Maui" Version="6.0.100-preview.5.794" />
-  </ItemGroup>
   <ItemGroup>
     <MauiSplashScreen Include="Resources\AppIcons\appiconfg.svg" Color="#512BD4" />
     <MauiImage Include="Resources\AppIcons\appicon.svg" ForegroundFile="Resources\AppIcons\appiconfg.svg" IsAppIcon="true" />

--- a/HelloMauiWinUI3/HelloMauiWinUI3/HelloMauiWinUI3.csproj
+++ b/HelloMauiWinUI3/HelloMauiWinUI3/HelloMauiWinUI3.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>net6.0-windows10.0.19041</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
     <RootNamespace>HelloMaui</RootNamespace>
 
@@ -12,15 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Maui" Version="6.0.100-preview.5.794" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.ProjectReunion" Version="0.8.0-preview" />
     <PackageReference Include="Microsoft.ProjectReunion.Foundation" Version="0.8.0-preview" />
     <PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="0.8.0-preview" />
-    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.19041.16" />
-    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.19041.16" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <!-- ensure only the sources defined below are used -->
+    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+    <add key="maui" value="https://aka.ms/maui-preview/index.json" />
+    <add key="public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+  </packageSources>
+  <config>
+    <add key="globalPackagesFolder" value="packages" />
+  </config>
+</configuration>

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ For more information and source code, visit [redth/dotnet-maui-check](https://gi
 
 If you prefer to install everything manually, you can find all of the official installer links below:
 
-* Windows: [dotnet-sdk-6.0.100-preview.5.21302.13-win-x64.exe](https://download.visualstudio.microsoft.com/download/pr/df52c798-6143-42f1-98e0-9cc7fc6257cd/cc09da4dcb8a59c1dcf905952f3382a1/dotnet-sdk-6.0.100-preview.5.21302.13-win-x64.exe)
-* macOS: [dotnet-sdk-6.0.100-preview.5.21302.13-osx-x64.pkg](https://download.visualstudio.microsoft.com/download/pr/134a7c15-69cf-40b3-ba78-a78a666ac2de/996de9580ee6c05b2bcb0e9456fdf877/dotnet-sdk-6.0.100-preview.5.21302.13-osx-x64.pkg)
+* Windows: [dotnet-sdk-6.0.100-preview.6.21313.2-win-x64.exe](https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100-preview.6.21313.2/dotnet-sdk-6.0.100-preview.6.21313.2-win-x64.exe)
+* macOS: [dotnet-sdk-6.0.100-preview.6.21313.2-osx-x64.pkg](https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100-preview.6.21313.2/dotnet-sdk-6.0.100-preview.6.21313.2-osx-x64.pkg)
 
 _NOTE: newer builds of .NET *may* work, but your mileage may vary.
 You can find the full list of builds at the [dotnet/installer][dotnet/installer] repo._

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,9 @@ pr:
 
 variables:
   IsRunningOnCI: true
-  DotNetVersion: 6.0.100-preview.5.21302.13
+  DotNetVersion: 6.0.100-preview.6.21313.2
   DotNet.Cli.Telemetry.OptOut: true
-  MauiCheck.Version: 0.5.6
-  MauiCheck.Manifest: https://raw.githubusercontent.com/Redth/dotnet-maui-check/main/manifests/maui-preview.manifest.json
+  MauiCheck.Version: 0.6.0-pre01
 
 jobs:
 - job: windows
@@ -32,7 +31,7 @@ jobs:
 
     - powershell: |
         & dotnet tool update --global redth.net.maui.check --version $(MauiCheck.Version) --add-source https://api.nuget.org/v3/index.json
-        & maui-check --ci --non-interactive --fix --skip androidsdk --skip xcode --skip vswin --skip vsmac --manifest $(MauiCheck.Manifest)
+        & maui-check --ci --non-interactive --fix --skip androidsdk --skip xcode --skip vswin --skip vsmac --main
       displayName: maui-check
       errorActionPreference: stop
 
@@ -97,7 +96,7 @@ jobs:
 
     - bash: >
         dotnet tool update --global redth.net.maui.check --version $(MauiCheck.Version) --add-source https://api.nuget.org/v3/index.json &&
-        maui-check --ci --non-interactive --fix --skip androidsdk --skip xcode --skip vswin --skip vsmac --manifest $(MauiCheck.Manifest)
+        maui-check --ci --non-interactive --fix --skip androidsdk --skip xcode --skip vswin --skip vsmac --main
       displayName: maui-check
 
     - bash: sudo xcode-select -s /Applications/Xcode_12.4.app

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "6.0.100-preview.5.21302.13",
+        "version": "6.0.100-preview.6.21313.2",
         "rollForward": "disable",
         "allowPrerelease": true
     }


### PR DESCRIPTION
* Use `maui-check --main`
* Workaround for `runtimeconfig.json`
* Use `UseMaui=true` instead of `@(PackageReference)`
* Change to `App.xaml.cs`
* Restore `NuGet.config` for nightly packages