### PR TITLE
[HelloiOS] Fix warning when building with preview 6

### DIFF
--- a/HelloiOS/Main.cs
+++ b/HelloiOS/Main.cs
@@ -9,7 +9,7 @@ namespace HelloiOS
         {
             // if you want to use a different Application Delegate class from "AppDelegate"
             // you can specify it here.
-            UIApplication.Main(args, null, "AppDelegate");
+            UIApplication.Main(args, null, typeof(AppDelegate));
         }
     }
 }


### PR DESCRIPTION
```
/Users/poupou/git/microsoft/maui-samples/HelloiOS/Main.cs(12,13): warning CS0618: 'UIApplication.Main(string[]?, string?, string?)' is obsolete: 'Use the overload with 'Type' instead of 'String' parameters for type safety.' [/Users/poupou/git/microsoft/maui-samples/HelloiOS/HelloiOS.csproj]
```

ref: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1355753

note: A larger template update will soon be available.