### PR TITLE
refreshview reverse listing

### DIFF
--- a/6.0/UserInterface/Views/RefreshViewDemo/RefreshViewDemo/MainPage.xaml
+++ b/6.0/UserInterface/Views/RefreshViewDemo/RefreshViewDemo/MainPage.xaml
@@ -26,7 +26,7 @@
 		<RefreshView IsRefreshing="{Binding IsRefreshing}"
                      RefreshColor="Teal"
                      Command="{Binding RefreshCommand}">
-			<ScrollView>
+            <ScrollView HeightRequest="500">
 				<FlexLayout Direction="Row"
                             Wrap="Wrap"
                             AlignItems="Center"

--- a/6.0/UserInterface/Views/RefreshViewDemo/RefreshViewDemo/MainPageViewModel.cs
+++ b/6.0/UserInterface/Views/RefreshViewDemo/RefreshViewDemo/MainPageViewModel.cs
@@ -37,7 +37,7 @@ namespace RefreshViewDemo
         {
             for (int i = 0; i < 50; i++)
             {
-                Items.Add(new Item
+                Items.Insert(0, new Item
                 {
                     Color = Color.FromRgb((byte)random.Next(0, 255), (byte)random.Next(0, 255), (byte)random.Next(0, 255)),
                     Name = $"Item {itemNumber++}"


### PR DESCRIPTION
When running this sample on phone devices, the items get hidden , because they are added at the end of the collection.
Also the scrollview cuts off 25% of the items. 
This PR improves upon that by 
1. adding new items on top correctly shows the refresh behavior.  
2. Fixing the height of the scrollview to enable view of all items in the collection.