### PR TITLE
Fix Build error in VideoDemo - 'IDispatcherTimer' could not be found

### DIFF
--- a/6.0/UserInterface/Handlers/CreateHandlerDemo/VideoDemos/Controls/Video.cs
+++ b/6.0/UserInterface/Handlers/CreateHandlerDemo/VideoDemos/Controls/Video.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Microsoft.Maui.Dispatching;
 
 namespace VideoDemos.Controls
 {


### PR DESCRIPTION
Fix https://github.com/dotnet/maui-samples/issues/256