### PR TITLE
fix #284 Status Tray not displaying on Mac

### DIFF
--- a/6.0/Apps/WeatherTwentyOne/src/WeatherTwentyOne/Platforms/MacCatalyst/TrayService.cs
+++ b/6.0/Apps/WeatherTwentyOne/src/WeatherTwentyOne/Platforms/MacCatalyst/TrayService.cs
@@ -38,7 +38,7 @@ public class TrayService : NSObject, ITrayService
         statusBarButton = Runtime.GetNSObject(IntPtr_objc_msgSend(statusBarItem.Handle, Selector.GetHandle("button")));
         statusBarImage = Runtime.GetNSObject(IntPtr_objc_msgSend(ObjCRuntime.Class.GetHandle("NSImage"), Selector.GetHandle("alloc")));
 
-        var imgPath = System.IO.Path.Combine(NSBundle.MainBundle.BundlePath, "Contents", "Resources", "MacCatalyst", "trayicon.png");
+        var imgPath = System.IO.Path.Combine(NSBundle.MainBundle.BundlePath, "Contents", "Resources", "Platforms", "MacCatalyst", "trayicon.png");
         var imageFileStr = NSString.CreateNative(imgPath);
         var nsImagePtr = IntPtr_objc_msgSend_IntPtr(statusBarImage.Handle, Selector.GetHandle("initWithContentsOfFile:"), imageFileStr);
 

--- a/6.0/Apps/WeatherTwentyOne/src/WeatherTwentyOne/WeatherTwentyOne.csproj
+++ b/6.0/Apps/WeatherTwentyOne/src/WeatherTwentyOne/WeatherTwentyOne.csproj
@@ -57,10 +57,14 @@
 
 	<ItemGroup>
 	  <None Remove="Platforms\Windows\trayicon.ico" />
+	  <None Remove="Platforms\MacCatalyst\trayicon.png" />
 	</ItemGroup>
 
 	<ItemGroup>
 	  <Content Include="Platforms\Windows\trayicon.ico">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	  <Content Include="Platforms\MacCatalyst\trayicon.png">
 	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </Content>
 	</ItemGroup>


### PR DESCRIPTION
The status item gets created, but is more or less invisible (though clickable), because the icon doesn't get copied.

Fixes #284