### PR TITLE
Update TwoPaneViewSample RC packages references to release versions

### DIFF
--- a/7.0/UserInterface/Views/TwoPaneView/TwoPaneViewSample.csproj
+++ b/7.0/UserInterface/Views/TwoPaneView/TwoPaneViewSample.csproj
@@ -49,8 +49,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0-rc.2.22430.11" />
-		<PackageReference Include="Microsoft.Maui.Controls.Foldable" Version="7.0.0-rc.2.6866" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Maui.Controls.Foldable" Version="7.0.58" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
The TwoPaneView sample doesn't work due to out of date package references.

This updates the packages references from the RC to the release versions.

This will resolve issue #321