### PR TITLE
Remove unnecessary code

### DIFF
--- a/Upgrading/CustomRenderer/MauiCustomRenderer/MauiProgram.cs
+++ b/Upgrading/CustomRenderer/MauiCustomRenderer/MauiProgram.cs
@@ -1,31 +1,28 @@
-﻿using Microsoft.Maui.Controls.Compatibility.Hosting;
-using XamarinCustomRenderer.Controls;
+﻿using XamarinCustomRenderer.Controls;
 
 namespace MauiCustomRenderer;
 
 public static class MauiProgram
 {
-public static MauiApp CreateMauiApp()
-{
-	var builder = MauiApp.CreateBuilder();
-	builder
-		.UseMauiApp<App>()
-		.UseMauiCompatibility()
-		.ConfigureFonts(fonts =>
-		{
-			fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
-			fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
-		})
-        .ConfigureMauiHandlers((handlers) =>{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .UseMauiApp<App>()
+            .ConfigureFonts(fonts =>
+            {
+                fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+                fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
+            })
+            .ConfigureMauiHandlers((handlers) =>
+            {
 #if ANDROID
-			handlers.AddHandler(typeof(PressableView),typeof(XamarinCustomRenderer.Droid.Renderers.PressableViewRenderer));
+                handlers.AddHandler(typeof(PressableView), typeof(XamarinCustomRenderer.Droid.Renderers.PressableViewRenderer));
+#elif IOS
+                handlers.AddHandler(typeof(PressableView), typeof(XamarinCustomRenderer.iOS.Renderers.PressableViewRenderer));
 #endif
+            });
 
-#if IOS
-            handlers.AddHandler(typeof(PressableView), typeof(XamarinCustomRenderer.iOS.Renderers.PressableViewRenderer));
-#endif
-        });
-
-	return builder.Build();
-}
+        return builder.Build();
+    }
 }


### PR DESCRIPTION
`UseMauiCompatibility` isn't required when consuming a `VisualElementRenderer`.