### PR TITLE
Removal of unnecessary command on MAUI Workload Install for MacOS

### DIFF
--- a/7.0/Apps/WeatherTwentyOne/devops/AzureDevOps/azdo_mac.yml
+++ b/7.0/Apps/WeatherTwentyOne/devops/AzureDevOps/azdo_mac.yml
@@ -29,7 +29,6 @@ stages:
         targetType: 'inline'
         script: |
           dotnet nuget locals all --clear
-          dotnet workload install maui --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json --source https://api.nuget.org/v3/index.json
           dotnet workload install android ios maccatalyst tvos macos maui wasm-tools --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json --source https://api.nuget.org/v3/index.json
 
     - task: Bash@3


### PR DESCRIPTION
MAUI workload install command is being invoked twice for this Azure Pipeline file. This is unnecessary. 