### PR TITLE
Remove dotnet-core metadata

### DIFF
--- a/7.0/Animations/README.md
+++ b/7.0/Animations/README.md
@@ -7,7 +7,6 @@ languages:
 - xaml
 products:
 - dotnet-maui
-- dotnet-core
 urlFragment: animations
 ---
 

--- a/7.0/Apps/PointOfSale/README.md
+++ b/7.0/Apps/PointOfSale/README.md
@@ -7,7 +7,6 @@ languages:
 - xaml
 products:
 - dotnet-maui
-- dotnet-core
 urlFragment: apps-pointofsale
 ---
 

--- a/7.0/Apps/WeatherTwentyOne/README.md
+++ b/7.0/Apps/WeatherTwentyOne/README.md
@@ -7,7 +7,6 @@ languages:
 - xaml
 products:
 - dotnet-maui
-- dotnet-core
 urlFragment: apps-weathertwentyone
 ---
 

--- a/7.0/Navigation/FlyoutPageSample/README.md
+++ b/7.0/Navigation/FlyoutPageSample/README.md
@@ -7,7 +7,6 @@ languages:
 - xaml
 products:
 - dotnet-maui
-- dotnet-core
 urlFragment: navigation-flyoutpage
 ---
 # FlyoutPage

--- a/7.0/Navigation/ShellFlyoutSample/README.md
+++ b/7.0/Navigation/ShellFlyoutSample/README.md
@@ -7,7 +7,6 @@ languages:
 - xaml
 products:
 - dotnet-maui
-- dotnet-core
 urlFragment: navigation-shellflyout
 ---
 # Shell Flyout

--- a/7.0/Navigation/ShellMixedSample/README.md
+++ b/7.0/Navigation/ShellMixedSample/README.md
@@ -7,7 +7,6 @@ languages:
 - xaml
 products:
 - dotnet-maui
-- dotnet-core
 urlFragment: navigation-shellmixed
 ---
 # Shell Mixed Navigation

--- a/7.0/Navigation/ShellTabBarSample/README.md
+++ b/7.0/Navigation/ShellTabBarSample/README.md
@@ -7,7 +7,6 @@ languages:
 - xaml
 products:
 - dotnet-maui
-- dotnet-core
 urlFragment: navigation-shelltabs
 ---
 # Shell Tabs

--- a/7.0/Navigation/TabbedPage/README.md
+++ b/7.0/Navigation/TabbedPage/README.md
@@ -7,7 +7,6 @@ languages:
 - xaml
 products:
 - dotnet-maui
-- dotnet-core
 urlFragment: navigation-tabbedpage
 ---
 # TabbedPage

--- a/Upgrading/CustomRenderer/README.md
+++ b/Upgrading/CustomRenderer/README.md
@@ -7,11 +7,9 @@ languages:
 - xaml
 products:
 - dotnet-maui
-- dotnet-core
 urlFragment: custom-renderers
 ---
 
 # Custom Renderers
 
 These projects show the same custom renderer used in Xamarin.Forms and .NET MAUI.
-

--- a/Upgrading/README.md
+++ b/Upgrading/README.md
@@ -7,7 +7,6 @@ languages:
 - xaml
 products:
 - dotnet-maui
-- dotnet-core
 urlFragment: upgrading
 ---
 


### PR DESCRIPTION
I don't think there's a need to also tag .NET MAUI samples as .NET Core. Also, we're trying to get rid of the ".NET Core" label since Core has been dropped from the name.

Contributes to https://github.com/dotnet/docs/issues/35970