### PR TITLE
Update localization sample

### DIFF
--- a/7.0/Fundamentals/Localization/LocalizationDemo/LocalizationDemo.csproj
+++ b/7.0/Fundamentals/Localization/LocalizationDemo/LocalizationDemo.csproj
@@ -41,12 +41,6 @@
 		<IPhoneResourcePrefix>Platforms/MacCatalyst/Resources</IPhoneResourcePrefix>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net7.0-ios|AnyCPU'">
-	  <CreatePackage>false</CreatePackage>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net7.0-ios|AnyCPU'">
-	  <CreatePackage>false</CreatePackage>
-	</PropertyGroup>
 	<ItemGroup>
 		<!-- App Icon -->
 		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
@@ -130,19 +124,12 @@
 	</ItemGroup>
 	
 	<ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
-	  <Content Include="Platforms\Windows\Assets\Images\de\flag.png" />
-	  <Content Include="Platforms\Windows\Assets\Images\en\flag.png" />
-	  <Content Include="Platforms\Windows\Assets\Images\es\flag.png" />
-	  <Content Include="Platforms\Windows\Assets\Images\fr\flag.png" />
-	  <Content Include="Platforms\Windows\Assets\Images\ja\flag.png" />
-	  <Content Include="Platforms\Windows\Assets\Images\pt-BR\flag.png" />
-	  <Content Include="Platforms\Windows\Assets\Images\pt\flag.png" />
-	  <Content Include="Platforms\Windows\Assets\Images\zh-Hans\flag.png" />
-	  <Content Include="Platforms\Windows\Assets\Images\zh-Hant\flag.png" />
+		<Content Include="Platforms\Windows\Assets\Images\**" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
-	
+
 	<ItemGroup Condition="$(TargetFramework.Contains('-android'))">
-	  <Folder Include="Platforms\Android\Resources\values-de\" />
+		<Folder Include="Platforms\Android\Resources\**" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" />
+	  <!--<Folder Include="Platforms\Android\Resources\values-de\" />
 	  <Folder Include="Platforms\Android\Resources\values-es\" />
 	  <Folder Include="Platforms\Android\Resources\values-gsw-rCH\" />
 	  <Folder Include="Platforms\Android\Resources\values-ja\" />
@@ -150,7 +137,7 @@
 	  <Folder Include="Platforms\Android\Resources\values-pt\" />
 	  <Folder Include="Platforms\Android\Resources\values-pt-rBR\" />
 	  <Folder Include="Platforms\Android\Resources\values-zh-rCN\" />
-	  <Folder Include="Platforms\Android\Resources\values-zh-rTW\" />
+	  <Folder Include="Platforms\Android\Resources\values-zh-rTW\" />-->
 	</ItemGroup>	
 
 </Project>

--- a/7.0/Fundamentals/Localization/LocalizationDemo/LocalizationDemo.csproj
+++ b/7.0/Fundamentals/Localization/LocalizationDemo/LocalizationDemo.csproj
@@ -80,64 +80,21 @@
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	</ItemGroup>
-	
+
+	<ItemGroup Condition="$(TargetFramework.Contains('-android'))">
+		<Folder Include="Platforms\Android\Resources\**" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" />
+	</ItemGroup>
+
 	<ItemGroup Condition="$(TargetFramework.Contains('-ios'))">
-	  <BundleResource Include="Platforms\iOS\Resources\de.lproj\flag.png" />
-	  <BundleResource Include="Platforms\iOS\Resources\en.lproj\flag.png" />
-	  <BundleResource Include="Platforms\iOS\Resources\es.lproj\flag.png" />
-	  <BundleResource Include="Platforms\iOS\Resources\fr.lproj\flag.png" />
-	  <BundleResource Include="Platforms\iOS\Resources\ja.lproj\flag.png" />
-	  <BundleResource Include="Platforms\iOS\Resources\pt-PT.lproj\flag.png" />
-	  <BundleResource Include="Platforms\iOS\Resources\pt.lproj\flag.png" />
-	  <BundleResource Include="Platforms\iOS\Resources\zh-Hans.lproj\flag.png" />
-	  <BundleResource Include="Platforms\iOS\Resources\zh-Hant.lproj\flag.png" />
-	  <BundleResource Include="Platforms\iOS\Resources\en.lproj\InfoPlist.strings" />
-	  <BundleResource Include="Platforms\iOS\Resources\de.lproj\InfoPlist.strings" />
-	  <BundleResource Include="Platforms\iOS\Resources\es.lproj\InfoPlist.strings" />
-	  <BundleResource Include="Platforms\iOS\Resources\fr.lproj\InfoPlist.strings" />
-	  <BundleResource Include="Platforms\iOS\Resources\ja.lproj\InfoPlist.strings" />
-	  <BundleResource Include="Platforms\iOS\Resources\pt-PT.lproj\InfoPlist.strings" />
-	  <BundleResource Include="Platforms\iOS\Resources\pt.lproj\InfoPlist.strings" />
-	  <BundleResource Include="Platforms\iOS\Resources\zh-Hans.lproj\InfoPlist.strings" />
-	  <BundleResource Include="Platforms\iOS\Resources\zh-Hant.lproj\InfoPlist.strings" />
+		<BundleResource Include="Platforms\iOS\Resources\**" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
 	
 	<ItemGroup Condition="$(TargetFramework.Contains('-maccatalyst'))">
-	  <BundleResource Include="Platforms\MacCatalyst\Resources\de.lproj\flag.png" />
-	  <BundleResource Include="Platforms\MacCatalyst\Resources\en.lproj\flag.png" />
-	  <BundleResource Include="Platforms\MacCatalyst\Resources\es.lproj\flag.png" />
-	  <BundleResource Include="Platforms\MacCatalyst\Resources\fr.lproj\flag.png" />
-	  <BundleResource Include="Platforms\MacCatalyst\Resources\ja.lproj\flag.png" />
-	  <BundleResource Include="Platforms\MacCatalyst\Resources\pt-PT.lproj\flag.png" />
-	  <BundleResource Include="Platforms\MacCatalyst\Resources\pt.lproj\flag.png" />
-	  <BundleResource Include="Platforms\MacCatalyst\Resources\zh-Hans.lproj\flag.png" />
-	  <BundleResource Include="Platforms\MacCatalyst\Resources\zh-Hant.lproj\flag.png" />
-	  <BundleResource Include="Platforms\MacCatalyst\Resources\en.lproj\InfoPlist.strings" />
-	  <BundleResource Include="Platforms\MacCatalyst\Resources\de.lproj\InfoPlist.strings" />
-	  <BundleResource Include="Platforms\MacCatalyst\Resources\es.lproj\InfoPlist.strings" />
-	  <BundleResource Include="Platforms\MacCatalyst\Resources\fr.lproj\InfoPlist.strings" />
-	  <BundleResource Include="Platforms\MacCatalyst\Resources\ja.lproj\InfoPlist.strings" />
-	  <BundleResource Include="Platforms\MacCatalyst\Resources\pt-PT.lproj\InfoPlist.strings" />
-	  <BundleResource Include="Platforms\MacCatalyst\Resources\pt.lproj\InfoPlist.strings" />
-	  <BundleResource Include="Platforms\MacCatalyst\Resources\zh-Hans.lproj\InfoPlist.strings" />
-	  <BundleResource Include="Platforms\MacCatalyst\Resources\zh-Hant.lproj\InfoPlist.strings" />
+		<BundleResource Include="Platforms\MacCatalyst\Resources\**" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
 	
 	<ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
 		<Content Include="Platforms\Windows\Assets\Images\**" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
-
-	<ItemGroup Condition="$(TargetFramework.Contains('-android'))">
-		<Folder Include="Platforms\Android\Resources\**" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" />
-	  <!--<Folder Include="Platforms\Android\Resources\values-de\" />
-	  <Folder Include="Platforms\Android\Resources\values-es\" />
-	  <Folder Include="Platforms\Android\Resources\values-gsw-rCH\" />
-	  <Folder Include="Platforms\Android\Resources\values-ja\" />
-	  <Folder Include="Platforms\Android\Resources\values-ms\" />
-	  <Folder Include="Platforms\Android\Resources\values-pt\" />
-	  <Folder Include="Platforms\Android\Resources\values-pt-rBR\" />
-	  <Folder Include="Platforms\Android\Resources\values-zh-rCN\" />
-	  <Folder Include="Platforms\Android\Resources\values-zh-rTW\" />-->
-	</ItemGroup>	
 
 </Project>

--- a/7.0/Fundamentals/Localization/LocalizationDemo/LocalizedPage.xaml
+++ b/7.0/Fundamentals/Localization/LocalizationDemo/LocalizedPage.xaml
@@ -6,7 +6,7 @@
              Title="{x:Static strings:AppResources.AddButton}">
     <VerticalStackLayout Margin="20"
                          Spacing="6">
-        <Image Source="{OnPlatform flag.png, WinUI=Platforms/Windows/Assets/Images/flag.png}"
+        <Image Source="flag.png"
                WidthRequest="100" />
         <Label Text="{x:Static strings:AppResources.NotesLabel}"
                WidthRequest="300"

--- a/7.0/Fundamentals/Localization/LocalizationDemo/SettingsPage.xaml
+++ b/7.0/Fundamentals/Localization/LocalizationDemo/SettingsPage.xaml
@@ -9,7 +9,6 @@
         <Color x:Key="SectionBorderColor">#C8C8C8</Color>
 
         <Style x:Key="SectionBorderStyle" TargetType="Frame">
-            <!--<Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource LightBackgroundSecondaryColor}, Dark={StaticResource DarkBackgroundSecondaryColor}}" />-->
             <Setter Property="BorderColor" Value="{StaticResource SectionBorderColor}" />
             <Setter Property="CornerRadius" Value="10" />
             <Setter Property="HasShadow" Value="False" />


### PR DESCRIPTION
Use wildcards in the .csproj to include platform resources. In particular, this removes the need to use the `OnPlatform` markup extension when loading localized images on Windows.