### PR TITLE
Add a GitHub Action to build all the samples in this repo

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -1,0 +1,27 @@
+name: Build All C# Projects
+
+on:
+  pull_request:
+    types:
+      - opened
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Find and build C# projects
+      run: |
+        find . -name '*.csproj' -type f | while read csproj; do
+          echo "Building $csproj"
+          dotnet build "$csproj"
+        done
+      shell: bash

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -1,27 +1,62 @@
-name: Build All C# Projects
+name: Build All C# Projects in Repo
 
 on:
-  pull_request:
-    types:
-      - opened
   workflow_dispatch:
 
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest]
+        os: [windows-latest, macos-13]
 
     runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
-    - name: Find and build C# projects
+    - name: Install .NET MAUI Workload
+      run: dotnet workload install maui
+      if: runner.os == 'macOS'
+      
+    - name: Find and build all C# projects
       run: |
-        find . -name '*.csproj' -type f | while read csproj; do
-          echo "Building $csproj"
-          dotnet build "$csproj"
-        done
-      shell: bash
+        $failedProjectCount=0
+        $jobSummaryFile=$env:GITHUB_STEP_SUMMARY
+        
+        Write-Output "# .NET MAUI Sample Apps Build Status (${{ runner.os }})" | Out-File -FilePath $jobSummaryFile -Append
+        Write-Output "| Project | Build Status |" | Out-File -FilePath $jobSummaryFile -Append
+        Write-Output "|---|---|" | Out-File -FilePath $jobSummaryFile -Append
+        
+        Get-ChildItem -Path . -Filter *.csproj -File -Recurse | ForEach-Object {
+            $csproj = $_.FullName
+            Write-Output "::group:: Building $csproj"
+
+            dotnet build $csproj
+        
+            if ($LASTEXITCODE -gt 0) {
+                Write-Output "::error:: Build failed for $csproj"
+                Write-Output "| $csproj | :x: |" | Out-File -FilePath $jobSummaryFile -Append
+        
+                $failedProjectCount++
+            }
+            else {
+                Write-Output "Build succeeded for $csproj"
+                Write-Output "| $csproj | :white_check_mark: |" | Out-File -FilePath $jobSummaryFile -Append
+            }
+        
+            $proj_dir = [System.IO.Path]::GetDirectoryName($csproj)
+            Write-Output "Cleaning up bin & obj in $proj_dir"
+            Get-ChildItem -Path $proj_dir -Directory -Recurse -Include bin,obj | Remove-Item -Recurse -Force
+        
+            Write-Output "::endgroup::"
+        }
+        
+        if ($failedProjectCount -gt 0) {
+            Write-Output "" | Out-File -FilePath $jobSummaryFile -Append
+            Write-Output "# Failed builds: $failedProjectCount" | Out-File -FilePath $jobSummaryFile -Append
+            
+            exit $failedProjectCount
+        }
+      shell: powershell

--- a/7.0/Beginners-Series/MauiApp2/MainPage.xaml.cs
+++ b/7.0/Beginners-Series/MauiApp2/MainPage.xaml.cs
@@ -8,7 +8,7 @@ public partial class MainPage : ContentPage
 	public MainPage(MainViewModel vm)
 	{
 		InitializeComponent();
-		BindingConteaxt = vm;
+		BindingContext = vm;
 	}
 }
 

--- a/7.0/Beginners-Series/MauiApp2/MainPage.xaml.cs
+++ b/7.0/Beginners-Series/MauiApp2/MainPage.xaml.cs
@@ -8,7 +8,7 @@ public partial class MainPage : ContentPage
 	public MainPage(MainViewModel vm)
 	{
 		InitializeComponent();
-		BindingContext = vm;
+		BindingConteaxt = vm;
 	}
 }
 


### PR DESCRIPTION
This adds a GitHub Action that can be triggered manually.

When triggered, it will loop through this repo searching for all *.csproj files and build them all through `dotnet build` on both Windows and macOS.

It will **not** fail early. It will go through all the projects and if it fails it will just put that on a list. In the summary of a GitHub Action run you will find a list of all the projects that have been built with the status: succeeded or failed.

This will give us an easy tool to quickly (although a full run takes 1-2 hours, optimizations are possible here) check if all samples build successfully.