### PR TITLE
Correct Build Action for Localization sample

### DIFF
--- a/7.0/Fundamentals/Localization/LocalizationDemo/LocalizationDemo.csproj
+++ b/7.0/Fundamentals/Localization/LocalizationDemo/LocalizationDemo.csproj
@@ -82,7 +82,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework.Contains('-android'))">
-		<Folder Include="Platforms\Android\Resources\**" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" />
+		<AndroidResource Include="Platforms\Android\Resources\**" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework.Contains('-ios'))">


### PR DESCRIPTION
The Build Action for the resources on the Android project were not correct. This resulted in an error while loading the project in Visual Studio.

Fixes #373