### PR TITLE
Add the ability to skip certain projects from automated building

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -16,46 +16,76 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    # Remove when .NET 8 is default on hosted runners
+    - name: Install .NET 8
+      uses: actions/setup-dotnet@v3.2.0
+      with:
+        dotnet-version: 8.0
+
     - name: Install .NET MAUI Workload
       run: dotnet workload install maui
-      if: runner.os == 'macOS'
+      # if: runner.os == 'macOS' # reenable when .NET 8 is default on hosted runners
+
+    - name: Select Xcode Version
+      run: sudo xcode-select -s /Applications/Xcode_15.0.1.app
+      if: runner.os == 'macOS' # Remove when Xcode 15+ is default on the hosted runners
       
     - name: Find and build all C# projects
       run: |
         $failedProjectCount=0
+        $skippedProjectCount=0
+        $excluded_projects_file="./eng/excluded_projects_" + "${{ runner.os }}".ToLower() + ".txt"
+        $excluded_projects=@()
+
         $jobSummaryFile=$env:GITHUB_STEP_SUMMARY
         
+        if (Test-Path $excluded_projects_file) {
+            $excluded_projects = Get-Content -Path $excluded_projects_file | Where-Object { $_ -notmatch "^\s*#" -and $_ -match "\S" }
+        }
+
         Write-Output "# .NET MAUI Sample Apps Build Status (${{ runner.os }})" | Out-File -FilePath $jobSummaryFile -Append
         Write-Output "| Project | Build Status |" | Out-File -FilePath $jobSummaryFile -Append
         Write-Output "|---|---|" | Out-File -FilePath $jobSummaryFile -Append
         
         Get-ChildItem -Path . -Filter *.csproj -File -Recurse | ForEach-Object {
             $csproj = $_.FullName
-            Write-Output "::group:: Building $csproj"
-
-            dotnet build $csproj
+            $relativePath = (Resolve-Path -Path $csproj -Relative).Replace("\", "/")
         
-            if ($LASTEXITCODE -gt 0) {
-                Write-Output "::error:: Build failed for $csproj"
-                Write-Output "| $csproj | :x: |" | Out-File -FilePath $jobSummaryFile -Append
+            # Check if the project is in the exclusion list
+            if ($excluded_projects -contains $relativePath) {
+                Write-Output "::notice:: Skipping build for excluded project: $relativePath"
+                Write-Output "| $csproj | Skipped |" | Out-File -FilePath $jobSummaryFile -Append
         
-                $failedProjectCount++
+                $skippedProjectCount++
             }
             else {
-                Write-Output "Build succeeded for $csproj"
-                Write-Output "| $csproj | :white_check_mark: |" | Out-File -FilePath $jobSummaryFile -Append
+                Write-Output "::group:: Building $csproj"
+        
+                dotnet build $csproj
+        
+                if ($LASTEXITCODE -gt 0) {
+                    Write-Output "::error:: Build failed for $csproj"
+                    Write-Output "| $relativePath | :x: |" | Out-File -FilePath $jobSummaryFile -Append
+        
+                    $failedProjectCount++
+                }
+                else {
+                    Write-Output "Build succeeded for $csproj"
+                    Write-Output "| $relativePath | :white_check_mark: |" | Out-File -FilePath $jobSummaryFile -Append
+                }
+        
+                $proj_dir = [System.IO.Path]::GetDirectoryName($csproj)
+                Write-Output "Cleaning up bin & obj in $proj_dir"
+                Get-ChildItem -Path $proj_dir -Directory -Recurse -Include bin,obj | Remove-Item -Recurse -Force
+        
+                Write-Output "::endgroup::"
             }
-        
-            $proj_dir = [System.IO.Path]::GetDirectoryName($csproj)
-            Write-Output "Cleaning up bin & obj in $proj_dir"
-            Get-ChildItem -Path $proj_dir -Directory -Recurse -Include bin,obj | Remove-Item -Recurse -Force
-        
-            Write-Output "::endgroup::"
         }
         
         if ($failedProjectCount -gt 0) {
             Write-Output "" | Out-File -FilePath $jobSummaryFile -Append
             Write-Output "# Failed builds: $failedProjectCount" | Out-File -FilePath $jobSummaryFile -Append
+            Write-Output "# Skipped builds: $skippedProjectCount" | Out-File -FilePath $jobSummaryFile -Append
             
             exit $failedProjectCount
         }

--- a/8.0/UserInterface/Views/GraphicsViewDemos/GraphicsViewDemos/GraphicsViewDemos.csproj
+++ b/8.0/UserInterface/Views/GraphicsViewDemos/GraphicsViewDemos/GraphicsViewDemos.csproj
@@ -4,7 +4,7 @@
 		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
+		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
 		<OutputType>Exe</OutputType>
 		<RootNamespace>GraphicsViewDemos</RootNamespace>
 		<UseMaui>true</UseMaui>

--- a/8.0/UserInterface/Views/Map/MapDemo/WorkingWithMaps/WorkingWithMaps.csproj
+++ b/8.0/UserInterface/Views/Map/MapDemo/WorkingWithMaps/WorkingWithMaps.csproj
@@ -4,7 +4,7 @@
 		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
+		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
 		<OutputType>Exe</OutputType>
 		<RootNamespace>WorkingWithMaps</RootNamespace>
 		<UseMaui>true</UseMaui>

--- a/8.0/WebServices/TodoREST/TodoAPI/TodoAPI.csproj
+++ b/8.0/WebServices/TodoREST/TodoAPI/TodoAPI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/Upgrading/CustomRenderer/MauiCustomRenderer/MauiCustomRenderer.csproj
+++ b/Upgrading/CustomRenderer/MauiCustomRenderer/MauiCustomRenderer.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
+		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
 		<OutputType>Exe</OutputType>
 		<RootNamespace>MauiCustomRenderer</RootNamespace>
 		<UseMaui>true</UseMaui>

--- a/eng/excluded_projects_macos.txt
+++ b/eng/excluded_projects_macos.txt
@@ -1,0 +1,11 @@
+# Add projects with relative paths and use forward slashes, for example: ./8.0/Sample/App/Project.csproj
+# This file excludes projects only for projects that are built on a macOS build host
+
+# Don't build all intermediate step projects. Only some projects actually build. This is intentional.
+./8.0/Tutorials/ConvertToMvvm/step2_model/Notes.csproj
+./8.0/Tutorials/ConvertToMvvm/step3_viewmodel_about/Notes.csproj
+./8.0/Tutorials/ConvertToMvvm/step4_viewmodel_note/Notes.csproj
+
+# Xamarin projects need to be built different, effort to set that up vs gain isn't worth doing that, so exclude
+./Upgrading/CustomRenderer/XamarinCustomRenderer/XamarinCustomRenderer/XamarinCustomRenderer.Android/XamarinCustomRenderer.Android.csproj
+./Upgrading/CustomRenderer/XamarinCustomRenderer/XamarinCustomRenderer/XamarinCustomRenderer.iOS/XamarinCustomRenderer.iOS.csproj

--- a/eng/excluded_projects_windows.txt
+++ b/eng/excluded_projects_windows.txt
@@ -1,0 +1,10 @@
+# Add projects with relative paths and use forward slashes, for example: ./8.0/Sample/App/Project.csproj
+
+# Don't build all intermediate step projects. Only some projects actually build. This is intentional.
+./8.0/Tutorials/ConvertToMvvm/step2_model/Notes.csproj
+./8.0/Tutorials/ConvertToMvvm/step3_viewmodel_about/Notes.csproj
+./8.0/Tutorials/ConvertToMvvm/step4_viewmodel_note/Notes.csproj
+
+# Xamarin projects need to be built different, effort to set that up vs gain isn't worth doing that, so exclude
+./Upgrading/CustomRenderer/XamarinCustomRenderer/XamarinCustomRenderer/XamarinCustomRenderer.Android/XamarinCustomRenderer.Android.csproj
+./Upgrading/CustomRenderer/XamarinCustomRenderer/XamarinCustomRenderer/XamarinCustomRenderer.iOS/XamarinCustomRenderer.iOS.csproj

--- a/eng/excluded_projects_windows.txt
+++ b/eng/excluded_projects_windows.txt
@@ -1,4 +1,5 @@
 # Add projects with relative paths and use forward slashes, for example: ./8.0/Sample/App/Project.csproj
+# This file excludes projects only for projects that are built on a Windows build host
 
 # Don't build all intermediate step projects. Only some projects actually build. This is intentional.
 ./8.0/Tutorials/ConvertToMvvm/step2_model/Notes.csproj


### PR DESCRIPTION
This change adds a way to exclude certain projects from the automated build in the GitHub Action.

Add projects with relative paths and use forward slashes in the `./eng/excluded_projects.txt` file, for example: `./8.0/Sample/App/Project.csproj`

The `#` sign can be used for comments, those will be filtered out.

Projects that need to be excluded right now have been added.

See this in action on this fork here: https://github.com/jfversluis/maui-samples/actions/runs/6932207281