### PR TITLE
Add GitHub Action to build PRs (only changed projects)

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,128 @@
+name: Build Changed C# Projects for PR
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-13]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+
+    # Remove when .NET 8 is default on hosted runners
+    - name: Install .NET 8
+      uses: actions/setup-dotnet@v3.2.0
+      with:
+        dotnet-version: 8.0
+
+    - name: Install .NET MAUI Workload
+      run: dotnet workload install maui
+      # if: runner.os == 'macOS' # reenable when .NET 8 is default on hosted runners
+
+    - name: Select Xcode Version
+      run: sudo xcode-select -s /Applications/Xcode_15.0.1.app
+      if: runner.os == 'macOS' # Remove when Xcode 15+ is default on the hosted runners
+
+    - name: Find and build changed projects
+      run: |
+        $failedProjectCount=0
+        # Get the list of changed files
+        $changedFiles = git diff --name-only -r HEAD^1 HEAD
+
+        $excluded_projects_file="./eng/excluded_projects_" + "${{ runner.os }}".ToLower() + ".txt"
+        $excluded_projects=@()
+        $processedProjects=@()
+
+        $jobSummaryFile=$env:GITHUB_STEP_SUMMARY
+
+        if (Test-Path $excluded_projects_file) {
+            $excluded_projects = Get-Content -Path $excluded_projects_file | Where-Object { $_ -notmatch "^\s*#" -and $_ -match "\S" }
+        }
+
+        Write-Output "# .NET MAUI Sample Apps Build Status (${{ runner.os }})" | Out-File -FilePath $jobSummaryFile -Append
+        Write-Output "Only projects that have changes are built." | Out-File -FilePath $jobSummaryFile -Append
+        Write-Output "| Project | Build Status |" | Out-File -FilePath $jobSummaryFile -Append
+        Write-Output "|---|---|" | Out-File -FilePath $jobSummaryFile -Append
+
+        # Determine the corresponding project for each changed file
+        foreach ($file in $changedFiles) {
+            $projectToBuild=""
+
+            # Check if the file is a .csproj file
+            if ($file -like '*.csproj') {
+              $projectToBuild = $file
+            } else {
+              $currentFolder = (Get-Item -LiteralPath (Resolve-Path -Path "$file")).Directory
+              
+              while ($currentFolder -ne $null) {
+                $csprojFiles = Get-ChildItem -Path $currentFolder -Filter '*.csproj' -File
+
+                if ($csprojFiles.Count -gt 0) {
+                  break
+                }
+                $currentFolder = Split-Path -Parent $currentFolder
+              }
+
+              $projectToBuild = $csprojFiles[0].FullName
+              Write-Output "Project to build: $projectToBuild"
+
+            }
+
+            # Only proceed when his project has not been built yet
+            if (-not ($processedProjects -contains $file)) {
+              if ([string]::IsNullOrEmpty($projectToBuild)) {
+                  Write-Output "::warning:: Found no csproj for file $file"
+              }
+              else {
+                $projectToBuild = (Resolve-Path -Path $projectToBuild -Relative).Replace("\", "/")
+
+                if ($excluded_projects -contains $projectToBuild) {
+                    Write-Output "::notice:: Skipping build for excluded project: $projectToBuild"
+                    Write-Output "| $projectToBuild | Skipped |" | Out-File -FilePath $jobSummaryFile -Append
+
+                    $skippedProjectCount++
+                }
+                else {
+                  Write-Output "::group:: Building $projectToBuild"
+
+                  dotnet build $projectToBuild
+                  $processedProjects += $projectToBuild
+
+                  if ($LASTEXITCODE -gt 0) {
+                    Write-Output "::error:: Build failed for $projectToBuild"
+                    Write-Output "| $projectToBuild | :x: |" | Out-File -FilePath $jobSummaryFile -Append
+
+                    $failedProjectCount++
+                  }
+                  else {
+                    Write-Output "Build succeeded for $projectToBuild"
+                    Write-Output "| $projectToBuild | :white_check_mark: |" | Out-File -FilePath $jobSummaryFile -Append
+                  }
+
+                  $proj_dir = [System.IO.Path]::GetDirectoryName($projectToBuild)
+                  Write-Output "Cleaning up bin & obj in $proj_dir"
+                  Get-ChildItem -Path $proj_dir -Directory -Recurse -Include bin,obj | Remove-Item -Recurse -Force
+
+                  Write-Output "::endgroup::"
+                }
+              }
+            }
+          }
+
+        if ($failedProjectCount -gt 0) {
+            Write-Output "" | Out-File -FilePath $jobSummaryFile -Append
+            Write-Output "# Failed builds: $failedProjectCount" | Out-File -FilePath $jobSummaryFile -Append
+            Write-Output "# Skipped builds: $skippedProjectCount" | Out-File -FilePath $jobSummaryFile -Append
+            
+            exit $failedProjectCount
+        }
+      shell: powershell

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -63,7 +63,7 @@ jobs:
             } else {
               $currentFolder = (Get-Item -LiteralPath (Resolve-Path -Path "$file")).Directory
               
-              while ($currentFolder -ne $null) {
+              while ($currentFolder -ne $null -and '' -ne $currentFolder) {
                 $csprojFiles = Get-ChildItem -Path $currentFolder -Filter '*.csproj' -File
 
                 if ($csprojFiles.Count -gt 0) {
@@ -72,9 +72,9 @@ jobs:
                 $currentFolder = Split-Path -Parent $currentFolder
               }
 
-              $projectToBuild = $csprojFiles[0].FullName
-              Write-Output "Project to build: $projectToBuild"
-
+              if ($csprojFiles.Count -gt 0) {
+                $projectToBuild = $csprojFiles[0].FullName
+              }
             }
 
             # Only proceed when his project has not been built yet


### PR DESCRIPTION
This adds a CI build for PRs that will look for the changed projects and only build those to make sure we don't introduce any breaking changes.

Builds are ran on both Windows and macOS.