### PR TITLE
Refresh BindingContext when Navigation is used in Commands in UserInterface samples

### DIFF
--- a/8.0/UserInterface/BrushesDemos/BrushesDemos/Views/MainPage.xaml.cs
+++ b/8.0/UserInterface/BrushesDemos/BrushesDemos/Views/MainPage.xaml.cs
@@ -19,4 +19,11 @@ public partial class MainPage : ContentPage
 
         BindingContext = this;
     }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        BindingContext = null;
+        BindingContext = this;
+    }
 }

--- a/8.0/UserInterface/ControlGallery/ControlGallery/Views/XAML/MainPage.xaml.cs
+++ b/8.0/UserInterface/ControlGallery/ControlGallery/Views/XAML/MainPage.xaml.cs
@@ -21,5 +21,12 @@ namespace ControlGallery
 
             BindingContext = this;
         }
+
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+            BindingContext = null;
+            BindingContext = this;
+        }
     }
 }

--- a/8.0/UserInterface/CustomLayoutDemos/CustomLayoutDemos/Views/MainPage.xaml.cs
+++ b/8.0/UserInterface/CustomLayoutDemos/CustomLayoutDemos/Views/MainPage.xaml.cs
@@ -19,5 +19,12 @@ public partial class MainPage : ContentPage
 
         BindingContext = this;
     }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        BindingContext = null;
+        BindingContext = this;
+    }
 }
 

--- a/8.0/UserInterface/Handlers/CreateHandlerDemo/VideoDemos/Views/MainPage.xaml.cs
+++ b/8.0/UserInterface/Handlers/CreateHandlerDemo/VideoDemos/Views/MainPage.xaml.cs
@@ -17,4 +17,11 @@ public partial class MainPage : ContentPage
         });
         BindingContext = this;
     }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        BindingContext = null;
+        BindingContext = this;
+    }
 }

--- a/8.0/UserInterface/Handlers/CustomizeHandlersDemo/CustomizeHandlersDemo/Views/MainPage.xaml.cs
+++ b/8.0/UserInterface/Handlers/CustomizeHandlersDemo/CustomizeHandlersDemo/Views/MainPage.xaml.cs
@@ -19,4 +19,11 @@ public partial class MainPage : ContentPage
 
         BindingContext = this;
     }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        BindingContext = null;
+        BindingContext = this;
+    }
 }

--- a/8.0/UserInterface/Layouts/AbsoluteLayoutDemos/AbsoluteLayoutDemos/Views/XAML/MainPage.xaml.cs
+++ b/8.0/UserInterface/Layouts/AbsoluteLayoutDemos/AbsoluteLayoutDemos/Views/XAML/MainPage.xaml.cs
@@ -20,5 +20,12 @@ namespace AbsoluteLayoutDemos
             BindingContext = this;
 
         }
+
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+            BindingContext = null;
+            BindingContext = this;
+        }
     }
 }

--- a/8.0/UserInterface/Layouts/BindableLayoutDemos/BindableLayoutDemos/Views/MainPage.xaml.cs
+++ b/8.0/UserInterface/Layouts/BindableLayoutDemos/BindableLayoutDemos/Views/MainPage.xaml.cs
@@ -19,6 +19,13 @@ namespace BindableLayoutDemos
 
             BindingContext = this;
         }
+
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+            BindingContext = null;
+            BindingContext = this;
+        }
 	}
 }
  

--- a/8.0/UserInterface/Layouts/FlexLayoutDemos/FlexLayoutDemos/Views/MainPage.xaml.cs
+++ b/8.0/UserInterface/Layouts/FlexLayoutDemos/FlexLayoutDemos/Views/MainPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows.Input;
+using System.Windows.Input;
 
 namespace FlexLayoutDemos
 {
@@ -17,6 +17,13 @@ namespace FlexLayoutDemos
                     await Navigation.PushAsync(page);
                 });
 
+            BindingContext = this;
+        }
+
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+            BindingContext = null;
             BindingContext = this;
         }
     }

--- a/8.0/UserInterface/Layouts/GridDemos/GridDemos/Views/XAML/MainPage.xaml.cs
+++ b/8.0/UserInterface/Layouts/GridDemos/GridDemos/Views/XAML/MainPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows.Input;
+using System.Windows.Input;
 
 namespace GridDemos
 {
@@ -17,6 +17,13 @@ namespace GridDemos
                     await Navigation.PushAsync(page);
                 });
 
+            BindingContext = this;
+        }
+
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+            BindingContext = null;
             BindingContext = this;
         }
 	}

--- a/8.0/UserInterface/Layouts/StackLayoutDemos/StackLayoutDemos/Views/XAML/MainPage.xaml.cs
+++ b/8.0/UserInterface/Layouts/StackLayoutDemos/StackLayoutDemos/Views/XAML/MainPage.xaml.cs
@@ -20,5 +20,12 @@ namespace StackLayoutDemos
             BindingContext = this;
 
         }
+
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+            BindingContext = null;
+            BindingContext = this;
+        }
     }
 }

--- a/8.0/UserInterface/Views/CarouselViewDemos/CarouselViewDemos/Views/MainPage.xaml.cs
+++ b/8.0/UserInterface/Views/CarouselViewDemos/CarouselViewDemos/Views/MainPage.xaml.cs
@@ -19,5 +19,12 @@ namespace CarouselViewDemos
 
             BindingContext = this;
         }
+
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+            BindingContext = null;
+            BindingContext = this;
+        }
     }
 }

--- a/8.0/UserInterface/Views/CheckBoxDemos/CheckBoxDemos/Views/MainPage.xaml.cs
+++ b/8.0/UserInterface/Views/CheckBoxDemos/CheckBoxDemos/Views/MainPage.xaml.cs
@@ -17,5 +17,12 @@ public partial class MainPage : ContentPage
         });
         BindingContext = this;
     }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        BindingContext = null;
+        BindingContext = this;
+    }
 }
 

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/MainPage.xaml.cs
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/MainPage.xaml.cs
@@ -19,5 +19,12 @@ namespace CollectionViewDemos
 
             BindingContext = this;
         }
+
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+            BindingContext = null;
+            BindingContext = this;
+        }
     }
 }

--- a/8.0/UserInterface/Views/GraphicsViewDemos/GraphicsViewDemos/Views/MainPage.xaml.cs
+++ b/8.0/UserInterface/Views/GraphicsViewDemos/GraphicsViewDemos/Views/MainPage.xaml.cs
@@ -19,5 +19,12 @@ namespace GraphicsViewDemos.Views
 
 			BindingContext = this;
 		}
+
+		protected override void OnAppearing()
+        {
+            base.OnAppearing();
+            BindingContext = null;
+            BindingContext = this;
+        }
 	}
 }

--- a/8.0/UserInterface/Views/IndicatorViewDemos/IndicatorViewDemos/Views/MainPage.xaml.cs
+++ b/8.0/UserInterface/Views/IndicatorViewDemos/IndicatorViewDemos/Views/MainPage.xaml.cs
@@ -19,5 +19,12 @@ public partial class MainPage : ContentPage
 
         BindingContext = this;
     }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        BindingContext = null;
+        BindingContext = this;
+    }
 }
 

--- a/8.0/UserInterface/Views/ListViewDemos/ListViewDemos/Views/MainPage.xaml.cs
+++ b/8.0/UserInterface/Views/ListViewDemos/ListViewDemos/Views/MainPage.xaml.cs
@@ -18,5 +18,12 @@ public partial class MainPage : ContentPage
 			});
 		BindingContext = this;
 	}
+
+	protected override void OnAppearing()
+	{
+		base.OnAppearing();
+		BindingContext = null;
+		BindingContext = this;
+	}
 }
 

--- a/8.0/UserInterface/Views/Map/MapDemo/WorkingWithMaps/Views/MainPage.xaml.cs
+++ b/8.0/UserInterface/Views/Map/MapDemo/WorkingWithMaps/Views/MainPage.xaml.cs
@@ -18,5 +18,12 @@ public partial class MainPage : ContentPage
 
         BindingContext = this;
     }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        BindingContext = null;
+        BindingContext = this;
+    }
 }
 

--- a/8.0/UserInterface/Views/RadioButtonDemos/RadioButtonDemos/Views/MainPage.xaml.cs
+++ b/8.0/UserInterface/Views/RadioButtonDemos/RadioButtonDemos/Views/MainPage.xaml.cs
@@ -17,5 +17,12 @@ public partial class MainPage : ContentPage
         });
         BindingContext = this;
     }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        BindingContext = null;
+        BindingContext = this;
+    }
 }
 

--- a/8.0/UserInterface/Views/ScrollViewDemos/ScrollViewDemos/Views/XAML/MainPage.xaml.cs
+++ b/8.0/UserInterface/Views/ScrollViewDemos/ScrollViewDemos/Views/XAML/MainPage.xaml.cs
@@ -19,4 +19,11 @@ public partial class MainPage : ContentPage
 
         BindingContext = this;
     }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        BindingContext = null;
+        BindingContext = this;
+    }
 }

--- a/8.0/UserInterface/Views/ShapesDemos/ShapesDemos/Views/MainPage.xaml.cs
+++ b/8.0/UserInterface/Views/ShapesDemos/ShapesDemos/Views/MainPage.xaml.cs
@@ -19,4 +19,11 @@ public partial class MainPage : ContentPage
 
         BindingContext = this;
     }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        BindingContext = null;
+        BindingContext = this;
+    }
 }

--- a/8.0/UserInterface/Views/SwipeViewDemos/SwipeViewDemos/Views/MainPage.xaml.cs
+++ b/8.0/UserInterface/Views/SwipeViewDemos/SwipeViewDemos/Views/MainPage.xaml.cs
@@ -19,5 +19,12 @@ public partial class MainPage : ContentPage
 
         BindingContext = this;
     }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        BindingContext = null;
+        BindingContext = this;
+    }
 }
 

--- a/8.0/UserInterface/Views/SwitchDemos/SwitchDemos/Views/MainPage.xaml.cs
+++ b/8.0/UserInterface/Views/SwitchDemos/SwitchDemos/Views/MainPage.xaml.cs
@@ -18,5 +18,12 @@ public partial class MainPage : ContentPage
 
         BindingContext = this;
     }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        BindingContext = null;
+        BindingContext = this;
+    }
 }
 

--- a/8.0/UserInterface/Views/TableViewDemos/TableViewDemos/Views/MainPage.xaml.cs
+++ b/8.0/UserInterface/Views/TableViewDemos/TableViewDemos/Views/MainPage.xaml.cs
@@ -18,4 +18,11 @@ public partial class MainPage : ContentPage
 			});
 		BindingContext = this;
 	}
+
+	protected override void OnAppearing()
+	{
+		base.OnAppearing();
+		BindingContext = null;
+		BindingContext = this;
+	}
 }


### PR DESCRIPTION
I've created an issue for it with a more detailed explanation: #484 https://github.com/dotnet/maui-samples/issues/484