### PR TITLE
[Collection view] Handle a reselect scenario

### DIFF
--- a/8.0/Fundamentals/Shell/Xaminals/Extensions/CollectionViewExtenstions.cs
+++ b/8.0/Fundamentals/Shell/Xaminals/Extensions/CollectionViewExtenstions.cs
@@ -1,0 +1,14 @@
+﻿namespace Xaminals.Extensions;
+
+public static class CollectionViewExtenstions
+{
+    public static bool ClearSelection(this CollectionView cv)
+    {
+        if (cv.SelectedItem == null)
+            return true;
+
+        cv.SelectedItem = null;
+        return false;
+    }
+}
+

--- a/8.0/Fundamentals/Shell/Xaminals/Views/BearsPage.xaml.cs
+++ b/8.0/Fundamentals/Shell/Xaminals/Views/BearsPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Xaminals.Models;
+﻿using Xaminals.Extensions;
+using Xaminals.Models;
 
 namespace Xaminals.Views
 {
@@ -11,6 +12,9 @@ namespace Xaminals.Views
 
         async void OnCollectionViewSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            if (((CollectionView)sender).ClearSelection())
+                return;
+
             Animal animal = e.CurrentSelection.FirstOrDefault() as Animal;
 
             var navigationParameter = new Dictionary<string, object>

--- a/8.0/Fundamentals/Shell/Xaminals/Views/CatsPage.xaml.cs
+++ b/8.0/Fundamentals/Shell/Xaminals/Views/CatsPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Xaminals.Models;
+﻿using Xaminals.Extensions;
+using Xaminals.Models;
 
 namespace Xaminals.Views
 {
@@ -11,6 +12,9 @@ namespace Xaminals.Views
 
         async void OnCollectionViewSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            if (((CollectionView)sender).ClearSelection())
+                return;
+
             string catName = (e.CurrentSelection.FirstOrDefault() as Animal).Name;
             // The following route works because route names are unique in this application.
             await Shell.Current.GoToAsync($"catdetails?name={catName}");

--- a/8.0/Fundamentals/Shell/Xaminals/Views/DogsPage.xaml.cs
+++ b/8.0/Fundamentals/Shell/Xaminals/Views/DogsPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Xaminals.Models;
+﻿using Xaminals.Extensions;
+using Xaminals.Models;
 
 namespace Xaminals.Views
 {
@@ -11,6 +12,9 @@ namespace Xaminals.Views
 
         async void OnCollectionViewSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            if (((CollectionView)sender).ClearSelection())
+                return;
+
             string dogName = (e.CurrentSelection.FirstOrDefault() as Animal).Name;
             // The following route works because route names are unique in this application.
             await Shell.Current.GoToAsync($"dogdetails?name={dogName}");

--- a/8.0/Fundamentals/Shell/Xaminals/Views/ElephantsPage.xaml.cs
+++ b/8.0/Fundamentals/Shell/Xaminals/Views/ElephantsPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Xaminals.Models;
+﻿using Xaminals.Extensions;
+using Xaminals.Models;
 
 namespace Xaminals.Views
 {
@@ -11,6 +12,9 @@ namespace Xaminals.Views
 
         async void OnCollectionViewSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            if (((CollectionView)sender).ClearSelection())
+                return;
+
             Animal animal = e.CurrentSelection.FirstOrDefault() as Animal;
             string elephantName = animal.Name;
 

--- a/8.0/Fundamentals/Shell/Xaminals/Views/MonkeysPage.xaml.cs
+++ b/8.0/Fundamentals/Shell/Xaminals/Views/MonkeysPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Xaminals.Models;
+﻿using Xaminals.Extensions;
+using Xaminals.Models;
 
 namespace Xaminals.Views
 {
@@ -11,6 +12,9 @@ namespace Xaminals.Views
 
         async void OnCollectionViewSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            if (((CollectionView)sender).ClearSelection())
+                return;
+
             Animal animal = e.CurrentSelection.FirstOrDefault() as Animal;
             var navigationParameters = new Dictionary<string, object>
             {


### PR DESCRIPTION
A common scenario is that users will select something and then navigate away. Once they navigate back the element is still selected which will result in users being unable to reselect the given item.
 
https://github.com/dotnet/maui/pull/21490#discussion_r1623301225

The original issue also points to our samples, because our samples don't allow reselection.
https://github.com/dotnet/maui/issues/20273

Fixes https://github.com/dotnet/docs-maui/issues/2362