### PR TITLE
Replace SL with Grid in CollectionViewDemo

### DIFF
--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/ViewModels/AnimalsViewModel.cs
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/ViewModels/AnimalsViewModel.cs
@@ -148,7 +148,7 @@ namespace CollectionViewDemos.ViewModels
             Animals.Add(new Animal
             {
                 Name = "Abyssinian",
-                Location = "Ethopia",
+                Location = "Ethiopia",
                 Details = "The Abyssinian is a breed of domestic short-haired cat with a distinctive tickedtabby coat, in which individual hairs are banded with different colors. The breed is named for Abyssinia (now called Ethiopia), where it is believed to have originated.",
                 ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Gustav_chocolate.jpg/168px-Gustav_chocolate.jpg"
             });

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/ViewModels/GroupedAnimalsViewModel.cs
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/ViewModels/GroupedAnimalsViewModel.cs
@@ -97,7 +97,7 @@ namespace CollectionViewDemos.ViewModels
                 new Animal
                 {
                     Name = "Abyssinian",
-                    Location = "Ethopia",
+                    Location = "Ethiopia",
                     Details = "The Abyssinian is a breed of domestic short-haired cat with a distinctive tickedtabby coat, in which individual hairs are banded with different colors. The breed is named for Abyssinia (now called Ethiopia), where it is believed to have originated.",
                     ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Gustav_chocolate.jpg/168px-Gustav_chocolate.jpg"
                 },

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/EmptyView/EmptyViewDataTemplateSelectorPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/EmptyView/EmptyViewDataTemplateSelectorPage.xaml
@@ -35,14 +35,16 @@
                                                  OtherTemplate="{StaticResource BasicTemplate}" />
     </ContentPage.Resources>
     
-    <StackLayout Margin="20">
+    <Grid RowDefinitions="Auto, *" 
+          Margin="20">
         <SearchBar x:Name="searchBar"
                    SearchCommand="{Binding FilterCommand}"
                    SearchCommandParameter="{Binding Source={x:Reference searchBar}, Path=Text}"
                    Placeholder="Filter" />
         <CollectionView ItemsSource="{Binding Monkeys}"
                         EmptyView="{Binding Source={x:Reference searchBar}, Path=Text}"
-                        EmptyViewTemplate="{StaticResource SearchSelector}">
+                        EmptyViewTemplate="{StaticResource SearchSelector}"
+                        Grid.Row="1">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -71,5 +73,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/EmptyView/EmptyViewFilteredPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/EmptyView/EmptyViewFilteredPage.xaml
@@ -3,13 +3,15 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
              x:Class="CollectionViewDemos.Views.EmptyViewFilteredPage"
              Title="EmptyView (string)">
-    <StackLayout Margin="20">
+    <Grid RowDefinitions="Auto, *" 
+          Margin="20">
         <SearchBar x:Name="searchBar"
                    SearchCommand="{Binding FilterCommand}"
                    SearchCommandParameter="{Binding Source={x:Reference searchBar}, Path=Text}"
                    Placeholder="Filter" />
         <CollectionView ItemsSource="{Binding Monkeys}"
-                        EmptyView="No items match your filter.">
+                        EmptyView="No items match your filter."
+                        Grid.Row="1">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -38,5 +40,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/EmptyView/EmptyViewLoadSimulationPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/EmptyView/EmptyViewLoadSimulationPage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
              x:Class="CollectionViewDemos.Views.EmptyViewLoadSimulationPage"
              Title="EmptyView (load simulation)">
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView x:Name="collectionView"
                         EmptyView="Loading items simulation.">
             <CollectionView.ItemTemplate>
@@ -34,5 +34,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/EmptyView/EmptyViewNullPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/EmptyView/EmptyViewNullPage.xaml
@@ -3,8 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
              x:Class="CollectionViewDemos.Views.EmptyViewNullPage"
              Title="EmptyView (Null ItemsSource)">
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView ItemsSource="{Binding EmptyMonkeys}"
                         EmptyView="No items to display" />
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/EmptyView/EmptyViewSwapPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/EmptyView/EmptyViewSwapPage.xaml
@@ -31,17 +31,19 @@
         </ContentView>
     </ContentPage.Resources>
     
-    <StackLayout Margin="20">
+    <Grid RowDefinitions="Auto, Auto, *" 
+          Margin="20">
         <SearchBar x:Name="searchBar"
                    SearchCommand="{Binding FilterCommand}"
                    SearchCommandParameter="{Binding Source={x:Reference searchBar}, Path=Text}"
                    Placeholder="Filter" />
-        <StackLayout Orientation="Horizontal">
+        <HorizontalStackLayout Grid.Row="1">
             <Label Text="Toggle EmptyViews" />
             <Switch Toggled="OnEmptyViewSwitchToggled" />
-        </StackLayout>
+        </HorizontalStackLayout>
         <CollectionView x:Name="collectionView"
-                        ItemsSource="{Binding Monkeys}">
+                        ItemsSource="{Binding Monkeys}"
+                        Grid.Row="2">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -70,5 +72,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/EmptyView/EmptyViewTemplatePage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/EmptyView/EmptyViewTemplatePage.xaml
@@ -4,12 +4,14 @@
              xmlns:controls="clr-namespace:CollectionViewDemos.Controls"
              x:Class="CollectionViewDemos.Views.EmptyViewTemplatePage"
              Title="EmptyView (template)">
-    <StackLayout Margin="20">
+    <Grid RowDefinitions="Auto, *" 
+          Margin="20">
         <SearchBar x:Name="searchBar"
                    SearchCommand="{Binding FilterCommand}"
                    SearchCommandParameter="{Binding Source={x:Reference searchBar}, Path=Text}"
                    Placeholder="Filter" />
-        <CollectionView ItemsSource="{Binding Monkeys}">
+        <CollectionView ItemsSource="{Binding Monkeys}"
+                        Grid.Row="1">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -51,5 +53,5 @@
                 </DataTemplate>
             </CollectionView.EmptyViewTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/EmptyView/EmptyViewWithViewsFilteredPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/EmptyView/EmptyViewWithViewsFilteredPage.xaml
@@ -3,12 +3,14 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="CollectionViewDemos.Views.EmptyViewWithViewsFilteredPage"
              Title="EmptyView (multiple views)">
-    <StackLayout Margin="20">
+    <Grid RowDefinitions="Auto, *" 
+          Margin="20">
         <SearchBar x:Name="searchBar"
                    SearchCommand="{Binding FilterCommand}"
                    SearchCommandParameter="{Binding Source={x:Reference searchBar}, Path=Text}"
                    Placeholder="Filter" />
-        <CollectionView ItemsSource="{Binding Monkeys}">
+        <CollectionView ItemsSource="{Binding Monkeys}"
+                        Grid.Row="1">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -55,5 +57,5 @@
                 </ContentView>
             </CollectionView.EmptyView>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Grouping/VerticalListEmptyGroupsPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Grouping/VerticalListEmptyGroupsPage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="CollectionViewDemos.Views.VerticalListEmptyGroupsPage"
              Title="Grouping including empty groups">
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView ItemsSource="{Binding Animals}"
                         IsGrouped="true">
             <CollectionView.ItemTemplate>
@@ -48,5 +48,5 @@
                 </DataTemplate>
             </CollectionView.GroupFooterTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Grouping/VerticalListGroupingPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Grouping/VerticalListGroupingPage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
              x:Class="CollectionViewDemos.Views.VerticalListGroupingPage"
              Title="Grouping (with DataTemplates)">
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView ItemsSource="{Binding Animals}"
                         IsGrouped="true">
             <CollectionView.ItemTemplate>
@@ -48,5 +48,5 @@
                 </DataTemplate>
             </CollectionView.GroupFooterTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Grouping/VerticalListGroupingVariableSizeItemsPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Grouping/VerticalListGroupingVariableSizeItemsPage.xaml
@@ -4,18 +4,19 @@
              xmlns:controls="clr-namespace:CollectionViewDemos.Controls"
              x:Class="CollectionViewDemos.Views.VerticalListGroupingVariableSizeItemsPage"
              Title="Grouping with variable sized items">
-    <StackLayout Margin="20">
-        <StackLayout Orientation="Horizontal"
-                     HorizontalOptions="Center">
+    <Grid RowDefinitions="Auto, *" 
+          Margin="20">
+        <HorizontalStackLayout HorizontalOptions="Center">
             <Label Text="ItemSizingStrategy:"
                    VerticalTextAlignment="Center" />
             <controls:EnumPicker x:Name="enumPicker"
                                  EnumType="{x:Type ItemSizingStrategy}"
                                  SelectedIndex="0" />
-        </StackLayout>
+        </HorizontalStackLayout>
         <CollectionView ItemsSource="{Binding Animals}"
                         IsGrouped="true"
-                        ItemSizingStrategy="{Binding Source={x:Reference enumPicker}, Path=SelectedItem}">
+                        ItemSizingStrategy="{Binding Source={x:Reference enumPicker}, Path=SelectedItem}"
+                        Grid.Row="1">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -56,7 +57,7 @@
                 </DataTemplate>
             </CollectionView.GroupFooterTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>
 
 

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Grouping/VerticalListTextGroupingPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Grouping/VerticalListTextGroupingPage.xaml
@@ -3,8 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
              x:Class="CollectionViewDemos.Views.VerticalListTextGroupingPage"
              Title="Grouping (without DataTemplates)">
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView ItemsSource="{Binding Animals}"
                         IsGrouped="true" />
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/HeadersAndFooters/HorizontalGridHeaderFooterViewPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/HeadersAndFooters/HorizontalGridHeaderFooterViewPage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="CollectionViewDemos.Views.HorizontalGridHeaderFooterViewPage"
              Title="Grid header and footer (View)">
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView ItemsSource="{Binding Monkeys}"
                         ItemsLayout="HorizontalGrid, 2">
             <CollectionView.Header>
@@ -50,5 +50,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/HeadersAndFooters/VerticalListHeaderFooterDataTemplatePage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/HeadersAndFooters/VerticalListHeaderFooterDataTemplatePage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="CollectionViewDemos.Views.VerticalListHeaderFooterDataTemplatePage"
              Title="Header and footer (DataTemplate)">
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView ItemsSource="{Binding Monkeys}"
                         Header="{Binding .}"
                         Footer="{Binding .}">
@@ -55,5 +55,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/HeadersAndFooters/VerticalListHeaderFooterStringPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/HeadersAndFooters/VerticalListHeaderFooterStringPage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="CollectionViewDemos.Views.VerticalListHeaderFooterStringPage"
              Title="Header and footer (string)">
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView ItemsSource="{Binding Monkeys}"
                         Header="Monkeys"
                         Footer="2019">
@@ -35,5 +35,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/HeadersAndFooters/VerticalListHeaderFooterViewPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/HeadersAndFooters/VerticalListHeaderFooterViewPage.xaml
@@ -3,7 +3,7 @@
               xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
               x:Class="CollectionViewDemos.Views.VerticalListHeaderFooterViewPage"
               Title="Header and footer (View)">
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView ItemsSource="{Binding Monkeys}">
             <CollectionView.Header>
                 <StackLayout BackgroundColor="LightGray">
@@ -49,5 +49,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Layout/HorizontalGridPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Layout/HorizontalGridPage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
              x:Class="CollectionViewDemos.Views.HorizontalGridPage"
              Title="Horizontal grid (DataTemplate)">
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView ItemsSource="{Binding Monkeys}"
                         ItemsLayout="HorizontalGrid, 4">
             <CollectionView.ItemTemplate>
@@ -36,5 +36,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Layout/HorizontalGridTextPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Layout/HorizontalGridTextPage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
              x:Class="CollectionViewDemos.Views.HorizontalGridTextPage"
              Title="Horizontal grid (text)">
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView ItemsLayout="HorizontalGrid, 4">
             <CollectionView.ItemsSource>
                 <x:Array Type="{x:Type x:String}">
@@ -27,5 +27,5 @@
                 </x:Array>
             </CollectionView.ItemsSource>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Layout/HorizontalListPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Layout/HorizontalListPage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
              x:Class="CollectionViewDemos.Views.HorizontalListPage"
              Title="Horizontal list (DataTemplate)">
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView ItemsSource="{Binding Monkeys}"
                         ItemsLayout="HorizontalList">
             <CollectionView.ItemTemplate>
@@ -36,5 +36,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Layout/HorizontalListTextPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Layout/HorizontalListTextPage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
              x:Class="CollectionViewDemos.Views.HorizontalListTextPage"
              Title="Horizontal list (text)">
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView ItemsLayout="HorizontalList">
             <CollectionView.ItemsSource>
                 <x:Array Type="{x:Type x:String}">
@@ -27,5 +27,5 @@
                 </x:Array>
             </CollectionView.ItemsSource>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Layout/VerticalGridPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Layout/VerticalGridPage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
              x:Class="CollectionViewDemos.Views.VerticalGridPage"
              Title="Vertical grid (DataTemplate)">
-  <StackLayout Margin="20">
+  <Grid Margin="20">
         <CollectionView ItemsSource="{Binding Monkeys}"
                         ItemsLayout="VerticalGrid, 2">
             <CollectionView.ItemTemplate>
@@ -36,5 +36,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Layout/VerticalGridTextPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Layout/VerticalGridTextPage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
              x:Class="CollectionViewDemos.Views.VerticalGridTextPage"
              Title="Vertical grid (text)">
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView ItemsLayout="VerticalGrid, 2">
             <CollectionView.ItemsSource>
                 <x:Array Type="{x:Type x:String}">
@@ -27,5 +27,5 @@
                 </x:Array>
             </CollectionView.ItemsSource>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Layout/VerticalListDataTemplateSelectorPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Layout/VerticalListDataTemplateSelectorPage.xaml
@@ -67,8 +67,8 @@
                                              OtherMonkey="{StaticResource OtherMonkeyTemplate}" />
     </ContentPage.Resources>
     
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView ItemsSource="{Binding Monkeys}"
                         ItemTemplate="{StaticResource MonkeySelector}" />
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Layout/VerticalListPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Layout/VerticalListPage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
              x:Class="CollectionViewDemos.Views.VerticalListPage"
              Title="Vertical list (DataTemplate)">
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView ItemsSource="{Binding Monkeys}">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
@@ -33,5 +33,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Layout/VerticalListRTLPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Layout/VerticalListRTLPage.xaml
@@ -4,7 +4,7 @@
              x:Class="CollectionViewDemos.Views.VerticalListRTLPage"
              Title="Vertical list (RTL FlowDirection)"
              FlowDirection="RightToLeft">
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView ItemsSource="{Binding Monkeys}">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
@@ -34,5 +34,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Layout/VerticalListTextPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Layout/VerticalListTextPage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="CollectionViewDemos.Views.VerticalListTextPage"
              Title="Vertical list (text)">
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView>
             <CollectionView.ItemsSource>
                 <x:Array Type="{x:Type x:String}">
@@ -27,5 +27,5 @@
                 </x:Array>
             </CollectionView.ItemsSource>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/IncrementalLoadingPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/IncrementalLoadingPage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="CollectionViewDemos.Views.IncrementalLoadingPage"
              Title="Incremental loading on scroll">
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView ItemsSource="{Binding Animals}"
                         RemainingItemsThreshold="5"
                         RemainingItemsThresholdReached="OnCollectionViewRemainingItemsThresholdReached"
@@ -36,5 +36,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ItemsUpdatingScrollModePage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ItemsUpdatingScrollModePage.xaml
@@ -6,15 +6,14 @@
              Title="Scroll mode when adding items">
     <Grid RowDefinitions="Auto, *"
           Margin="20" >
-        <StackLayout Orientation="Horizontal"
-                     HorizontalOptions="Center">
+        <HorizontalStackLayout HorizontalOptions="Center">
             <Label Text="UpdatingScrollMode: "
                    VerticalTextAlignment="Center" />
             <controls:EnumPicker x:Name="enumPicker"
                                  EnumType="{x:Type ItemsUpdatingScrollMode}"
                                  SelectedIndex="0"
                                  SelectedIndexChanged="OnItemsUpdatingScrollModeChanged" />
-        </StackLayout>
+        </HorizontalStackLayout>
         <CollectionView x:Name="collectionView"
                         ItemsSource="{Binding Monkeys}"
                         Grid.Row="1">

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ItemsUpdatingScrollModePage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ItemsUpdatingScrollModePage.xaml
@@ -4,7 +4,7 @@
              xmlns:controls="clr-namespace:CollectionViewDemos.Controls"
              x:Class="CollectionViewDemos.Views.ItemsUpdatingScrollModePage"
              Title="Scroll mode when adding items">
-    <StackLayout Margin="20">
+    <Grid Margin="20" RowDefinitions="Auto, *">
         <StackLayout Orientation="Horizontal"
                      HorizontalOptions="Center">
             <Label Text="UpdatingScrollMode: "
@@ -15,7 +15,8 @@
                                  SelectedIndexChanged="OnItemsUpdatingScrollModeChanged" />
         </StackLayout>
         <CollectionView x:Name="collectionView"
-                        ItemsSource="{Binding Monkeys}">
+                        ItemsSource="{Binding Monkeys}"
+                        Grid.Row="1">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -44,5 +45,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ItemsUpdatingScrollModePage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ItemsUpdatingScrollModePage.xaml
@@ -4,7 +4,8 @@
              xmlns:controls="clr-namespace:CollectionViewDemos.Controls"
              x:Class="CollectionViewDemos.Views.ItemsUpdatingScrollModePage"
              Title="Scroll mode when adding items">
-    <Grid Margin="20" RowDefinitions="Auto, *">
+    <Grid RowDefinitions="Auto, *"
+          Margin="20" >
         <StackLayout Orientation="Horizontal"
                      HorizontalOptions="Center">
             <Label Text="UpdatingScrollMode: "

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByIndexPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByIndexPage.xaml
@@ -4,8 +4,8 @@
              xmlns:controls="clr-namespace:CollectionViewDemos.Controls"
              x:Class="CollectionViewDemos.Views.ScrollToByIndexPage"
              Title="Scroll to index">
-    <Grid Margin="20" 
-          RowDefinitions="Auto, Auto, Auto, *">
+    <Grid RowDefinitions="Auto, Auto, Auto, *"
+          Margin="20">
         <StackLayout Orientation="Horizontal"
                      HorizontalOptions="Center">
             <Label Text="ScrollToPosition: "

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByIndexPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByIndexPage.xaml
@@ -4,7 +4,8 @@
              xmlns:controls="clr-namespace:CollectionViewDemos.Controls"
              x:Class="CollectionViewDemos.Views.ScrollToByIndexPage"
              Title="Scroll to index">
-    <StackLayout Margin="20">
+    <Grid Margin="20" 
+          RowDefinitions="Auto, Auto, Auto, *">
         <StackLayout Orientation="Horizontal"
                      HorizontalOptions="Center">
             <Label Text="ScrollToPosition: "
@@ -14,17 +15,20 @@
                                  SelectedIndex="0" />
         </StackLayout>
         <StackLayout Orientation="Horizontal"
-                     HorizontalOptions="Center">
+                     HorizontalOptions="Center"
+                     Grid.Row="1">
             <Label Text="Animate scroll: "
                    VerticalTextAlignment="Center" />
             <Switch x:Name="animateSwitch"
                     IsToggled="true" />
         </StackLayout>
         <Button Text="Scroll to item 12"
-                Clicked="OnButtonClicked" />
+                Clicked="OnButtonClicked"
+                Grid.Row="2" />
         <CollectionView x:Name="collectionView"
                         ItemsSource="{Binding Monkeys}"
-                        Scrolled="OnCollectionViewScrolled">
+                        Scrolled="OnCollectionViewScrolled"
+                        Grid.Row="3">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -53,5 +57,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByIndexPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByIndexPage.xaml
@@ -6,22 +6,20 @@
              Title="Scroll to index">
     <Grid RowDefinitions="Auto, Auto, Auto, *"
           Margin="20">
-        <StackLayout Orientation="Horizontal"
-                     HorizontalOptions="Center">
+        <HorizontalStackLayout HorizontalOptions="Center">
             <Label Text="ScrollToPosition: "
                    VerticalTextAlignment="Center" />
             <controls:EnumPicker x:Name="enumPicker"
                                  EnumType="{x:Type ScrollToPosition}"
                                  SelectedIndex="0" />
-        </StackLayout>
-        <StackLayout Orientation="Horizontal"
-                     HorizontalOptions="Center"
-                     Grid.Row="1">
+        </HorizontalStackLayout>
+        <HorizontalStackLayout HorizontalOptions="Center"
+                               Grid.Row="1">
             <Label Text="Animate scroll: "
                    VerticalTextAlignment="Center" />
             <Switch x:Name="animateSwitch"
                     IsToggled="true" />
-        </StackLayout>
+        </HorizontalStackLayout>
         <Button Text="Scroll to item 12"
                 Clicked="OnButtonClicked"
                 Grid.Row="2" />

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByIndexWithGroupingPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByIndexWithGroupingPage.xaml
@@ -4,8 +4,8 @@
              xmlns:controls="clr-namespace:CollectionViewDemos.Controls"
              x:Class="CollectionViewDemos.Views.ScrollToByIndexWithGroupingPage"
              Title="Scroll to index (grouped data)">
-    <Grid Margin="20"
-          RowDefinitions="Auto, Auto, Auto, *">
+    <Grid RowDefinitions="Auto, Auto, Auto, *"
+          Margin="20">
         <StackLayout Orientation="Horizontal"
                      HorizontalOptions="Center">
             <Label Text="ScrollToPosition: "

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByIndexWithGroupingPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByIndexWithGroupingPage.xaml
@@ -4,7 +4,8 @@
              xmlns:controls="clr-namespace:CollectionViewDemos.Controls"
              x:Class="CollectionViewDemos.Views.ScrollToByIndexWithGroupingPage"
              Title="Scroll to index (grouped data)">
-    <StackLayout Margin="20">
+    <Grid Margin="20"
+          RowDefinitions="Auto, Auto, Auto, *">
         <StackLayout Orientation="Horizontal"
                      HorizontalOptions="Center">
             <Label Text="ScrollToPosition: "
@@ -14,18 +15,21 @@
                                  SelectedIndex="0" />
         </StackLayout>
         <StackLayout Orientation="Horizontal"
-                     HorizontalOptions="Center">
+                     HorizontalOptions="Center"
+                     Grid.Row="1">
             <Label Text="Animate scroll: "
                    VerticalTextAlignment="Center" />
             <Switch x:Name="animateSwitch"
                     IsToggled="true" />
         </StackLayout>
         <Button Text="Scroll to third cat"
-                Clicked="OnButtonClicked" />
+                Clicked="OnButtonClicked"
+                Grid.Row="2" />
         <CollectionView x:Name="collectionView"
                         ItemsSource="{Binding Animals}"
                         IsGrouped="true"
-                        Scrolled="OnCollectionViewScrolled">
+                        Scrolled="OnCollectionViewScrolled"
+                        Grid.Row="3">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -68,5 +72,5 @@
                 </DataTemplate>
             </CollectionView.GroupFooterTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByIndexWithGroupingPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByIndexWithGroupingPage.xaml
@@ -6,22 +6,20 @@
              Title="Scroll to index (grouped data)">
     <Grid RowDefinitions="Auto, Auto, Auto, *"
           Margin="20">
-        <StackLayout Orientation="Horizontal"
-                     HorizontalOptions="Center">
+        <HorizontalStackLayout HorizontalOptions="Center">
             <Label Text="ScrollToPosition: "
                    VerticalTextAlignment="Center" />
             <controls:EnumPicker x:Name="enumPicker"
                                  EnumType="{x:Type ScrollToPosition}"
                                  SelectedIndex="0" />
-        </StackLayout>
-        <StackLayout Orientation="Horizontal"
-                     HorizontalOptions="Center"
-                     Grid.Row="1">
+        </HorizontalStackLayout>
+        <HorizontalStackLayout HorizontalOptions="Center"
+                               Grid.Row="1">
             <Label Text="Animate scroll: "
                    VerticalTextAlignment="Center" />
             <Switch x:Name="animateSwitch"
                     IsToggled="true" />
-        </StackLayout>
+        </HorizontalStackLayout>
         <Button Text="Scroll to third cat"
                 Clicked="OnButtonClicked"
                 Grid.Row="2" />

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByObjectPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByObjectPage.xaml
@@ -4,8 +4,8 @@
              xmlns:controls="clr-namespace:CollectionViewDemos.Controls"
              x:Class="CollectionViewDemos.Views.ScrollToByObjectPage"
              Title="Scroll to object">
-    <Grid Margin="20"
-          RowDefinitions="Auto, Auto, Auto, *">
+    <Grid RowDefinitions="Auto, Auto, Auto, *"
+          Margin="20">
         <StackLayout Orientation="Horizontal"
                      HorizontalOptions="Center">
             <Label Text="ScrollToPosition: "

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByObjectPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByObjectPage.xaml
@@ -6,22 +6,20 @@
              Title="Scroll to object">
     <Grid RowDefinitions="Auto, Auto, Auto, *"
           Margin="20">
-        <StackLayout Orientation="Horizontal"
-                     HorizontalOptions="Center">
+        <HorizontalStackLayout HorizontalOptions="Center">
             <Label Text="ScrollToPosition: "
                    VerticalTextAlignment="Center" />
             <controls:EnumPicker x:Name="enumPicker"
                                  EnumType="{x:Type ScrollToPosition}"
                                  SelectedIndex="0" />
-        </StackLayout>
-        <StackLayout Orientation="Horizontal"
-                     HorizontalOptions="Center"
-                     Grid.Row="1">
+        </HorizontalStackLayout>
+        <HorizontalStackLayout HorizontalOptions="Center"
+                               Grid.Row="1">
             <Label Text="Animate scroll: "
                    VerticalTextAlignment="Center" />
             <Switch x:Name="animateSwitch"
                     IsToggled="true" />
-        </StackLayout>
+        </HorizontalStackLayout>
         <Button Text="Scroll to Proboscis Monkey"
                 Clicked="OnButtonClicked"
                 Grid.Row="2" />

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByObjectPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByObjectPage.xaml
@@ -4,7 +4,8 @@
              xmlns:controls="clr-namespace:CollectionViewDemos.Controls"
              x:Class="CollectionViewDemos.Views.ScrollToByObjectPage"
              Title="Scroll to object">
-    <StackLayout Margin="20">
+    <Grid Margin="20"
+          RowDefinitions="Auto, Auto, Auto, *">
         <StackLayout Orientation="Horizontal"
                      HorizontalOptions="Center">
             <Label Text="ScrollToPosition: "
@@ -14,17 +15,20 @@
                                  SelectedIndex="0" />
         </StackLayout>
         <StackLayout Orientation="Horizontal"
-                     HorizontalOptions="Center">
+                     HorizontalOptions="Center"
+                     Grid.Row="1">
             <Label Text="Animate scroll: "
                    VerticalTextAlignment="Center" />
             <Switch x:Name="animateSwitch"
                     IsToggled="true" />
         </StackLayout>
         <Button Text="Scroll to Proboscis Monkey"
-                Clicked="OnButtonClicked" />
+                Clicked="OnButtonClicked"
+                Grid.Row="2" />
         <CollectionView x:Name="collectionView"
                         ItemsSource="{Binding Monkeys}"
-                        Scrolled="OnCollectionViewScrolled">
+                        Scrolled="OnCollectionViewScrolled"
+                        Grid.Row="3">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -53,5 +57,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByObjectWithGroupingPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByObjectWithGroupingPage.xaml
@@ -4,8 +4,8 @@
              xmlns:controls="clr-namespace:CollectionViewDemos.Controls"
              x:Class="CollectionViewDemos.Views.ScrollToByObjectWithGroupingPage"
              Title="Scroll to object (grouped data)">
-    <Grid Margin="20"
-          RowDefinitions="Auto, Auto, Auto, *">
+    <Grid RowDefinitions="Auto, Auto, Auto, *"
+          Margin="20">
         <StackLayout Orientation="Horizontal"
                      HorizontalOptions="Center">
             <Label Text="ScrollToPosition: "

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByObjectWithGroupingPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByObjectWithGroupingPage.xaml
@@ -6,22 +6,20 @@
              Title="Scroll to object (grouped data)">
     <Grid RowDefinitions="Auto, Auto, Auto, *"
           Margin="20">
-        <StackLayout Orientation="Horizontal"
-                     HorizontalOptions="Center">
+        <HorizontalStackLayout HorizontalOptions="Center">
             <Label Text="ScrollToPosition: "
                    VerticalTextAlignment="Center" />
             <controls:EnumPicker x:Name="enumPicker"
                                  EnumType="{x:Type ScrollToPosition}"
                                  SelectedIndex="0" />
-        </StackLayout>
-        <StackLayout Orientation="Horizontal"
-                     HorizontalOptions="Center"
-                     Grid.Row="1">
+        </HorizontalStackLayout>
+        <HorizontalStackLayout HorizontalOptions="Center"
+                               Grid.Row="1">
             <Label Text="Animate scroll: "
                    VerticalTextAlignment="Center" />
             <Switch x:Name="animateSwitch"
                     IsToggled="true" />
-        </StackLayout>
+        </HorizontalStackLayout>
         <Button Text="Scroll to Proboscis Monkey"
                 Clicked="OnButtonClicked"
                 Grid.Row="2" />

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByObjectWithGroupingPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Scrolling/ScrollToByObjectWithGroupingPage.xaml
@@ -4,7 +4,8 @@
              xmlns:controls="clr-namespace:CollectionViewDemos.Controls"
              x:Class="CollectionViewDemos.Views.ScrollToByObjectWithGroupingPage"
              Title="Scroll to object (grouped data)">
-    <StackLayout Margin="20">
+    <Grid Margin="20"
+          RowDefinitions="Auto, Auto, Auto, *">
         <StackLayout Orientation="Horizontal"
                      HorizontalOptions="Center">
             <Label Text="ScrollToPosition: "
@@ -14,18 +15,21 @@
                                  SelectedIndex="0" />
         </StackLayout>
         <StackLayout Orientation="Horizontal"
-                     HorizontalOptions="Center">
+                     HorizontalOptions="Center"
+                     Grid.Row="1">
             <Label Text="Animate scroll: "
                    VerticalTextAlignment="Center" />
             <Switch x:Name="animateSwitch"
                     IsToggled="true" />
         </StackLayout>
         <Button Text="Scroll to Proboscis Monkey"
-                Clicked="OnButtonClicked" />
+                Clicked="OnButtonClicked"
+                Grid.Row="2" />
         <CollectionView x:Name="collectionView"
                         ItemsSource="{Binding Animals}"
                         IsGrouped="true"
-                        Scrolled="OnCollectionViewScrolled">
+                        Scrolled="OnCollectionViewScrolled"
+                        Grid.Row="3">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -68,5 +72,5 @@
                 </DataTemplate>
             </CollectionView.GroupFooterTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Selection/VerticalListMultiplePreSelectionPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Selection/VerticalListMultiplePreSelectionPage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="CollectionViewDemos.Views.VerticalListMultiplePreSelectionPage"
              Title="Vertical list (multiple pre-selection)">
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView x:Name="collectionView"
                         ItemsSource="{Binding Monkeys}"
                         SelectionMode="Multiple"
@@ -36,5 +36,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Selection/VerticalListMultipleSelectionPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Selection/VerticalListMultipleSelectionPage.xaml
@@ -3,7 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
              x:Class="CollectionViewDemos.Views.VerticalListMultipleSelectionPage"
              Title="Vertical list (multiple selection)">
-    <StackLayout Margin="20">
+    <Grid RowDefinitions="Auto, *"  
+          Margin="20">
         <ScrollView HeightRequest="150">
             <Grid>
                 <Grid.RowDefinitions>
@@ -26,7 +27,8 @@
         </ScrollView>
         <CollectionView ItemsSource="{Binding Monkeys}"
                         SelectionMode="Multiple"
-                        SelectionChanged="OnCollectionViewSelectionChanged">
+                        SelectionChanged="OnCollectionViewSelectionChanged"
+                        Grid.Row="1">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -55,5 +57,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Selection/VerticalListSelectionColorPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Selection/VerticalListSelectionColorPage.xaml
@@ -20,7 +20,7 @@
             </Setter>
         </Style>
     </ContentPage.Resources>
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView ItemsSource="{Binding Monkeys}"
                         SelectionMode="Single">
             <CollectionView.ItemTemplate>
@@ -51,5 +51,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Selection/VerticalListSinglePreSelectionPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Selection/VerticalListSinglePreSelectionPage.xaml
@@ -3,12 +3,14 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
              x:Class="CollectionViewDemos.Views.VerticalListSinglePreSelectionPage"
              Title="Vertical list (single pre-selection)">
-<StackLayout Margin="20">
+    <Grid RowDefinitions="Auto, *" 
+          Margin="20">
         <Label Text="{Binding SelectedMonkeyMessage}" />
         <CollectionView ItemsSource="{Binding Monkeys}"
                         SelectionMode="Single"
                         SelectedItem="{Binding SelectedMonkey}"
-                        SelectionChangedCommand="{Binding MonkeySelectionChangedCommand}">
+                        SelectionChangedCommand="{Binding MonkeySelectionChangedCommand}"
+                        Grid.Row="1">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -37,5 +39,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Selection/VerticalListSingleSelectionPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Selection/VerticalListSingleSelectionPage.xaml
@@ -3,7 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="CollectionViewDemos.Views.VerticalListSingleSelectionPage"
              Title="Vertical list (single selection)">
-    <StackLayout Margin="20">
+    <Grid RowDefinitions="Auto, *" 
+          Margin="20">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
@@ -24,7 +25,8 @@
         </Grid>
         <CollectionView ItemsSource="{Binding Monkeys}"
                         SelectionMode="Single"
-                        SelectionChanged="OnCollectionViewSelectionChanged">
+                        SelectionChanged="OnCollectionViewSelectionChanged"
+                        Grid.Row="1">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -53,5 +55,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Sizing/VerticalListDynamicSizeItemsPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Sizing/VerticalListDynamicSizeItemsPage.xaml
@@ -3,9 +3,11 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="CollectionViewDemos.Views.VerticalListDynamicSizeItemsPage"
              Title="Vertical list (dynamic item sizing)">
-    <StackLayout Margin="20">
+    <Grid RowDefinitions="Auto, *" 
+          Margin="20">
         <Label Text="Tap each image to dynamically change its size." />
-        <CollectionView ItemsSource="{Binding Monkeys}">
+        <CollectionView ItemsSource="{Binding Monkeys}"
+                        Grid.Row="1">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -38,5 +40,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Sizing/VerticalListVariableSizeItemsPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Sizing/VerticalListVariableSizeItemsPage.xaml
@@ -4,17 +4,18 @@
              xmlns:controls="clr-namespace:CollectionViewDemos.Controls"
              x:Class="CollectionViewDemos.Views.VerticalListVariableSizeItemsPage"
              Title="Vertical list (variable size items)">
-  <StackLayout Margin="20">
-        <StackLayout Orientation="Horizontal"
-                     HorizontalOptions="Center">
+  <Grid RowDefinitions="Auto, *" 
+        Margin="20">
+        <HorizontalStackLayout HorizontalOptions="Center">
             <Label Text="ItemSizingStrategy:"
                    VerticalTextAlignment="Center" />
             <controls:EnumPicker x:Name="enumPicker"
                                  EnumType="{x:Type ItemSizingStrategy}"
                                  SelectedIndex="0" />
-        </StackLayout>
+        </HorizontalStackLayout>
         <CollectionView ItemsSource="{Binding Monkeys}" 
-                        ItemSizingStrategy="{Binding Source={x:Reference enumPicker}, Path=SelectedItem}">
+                        ItemSizingStrategy="{Binding Source={x:Reference enumPicker}, Path=SelectedItem}"
+                        Grid.Row="1">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -41,5 +42,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/SnapPoints/VerticalListSnapPointsPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/SnapPoints/VerticalListSnapPointsPage.xaml
@@ -6,25 +6,23 @@
              Title="Vertical list (snap points)">
     <Grid RowDefinitions="Auto, Auto, *"
           Margin="20">
-        <StackLayout Orientation="Horizontal"
-                     HorizontalOptions="Center">
+        <HorizontalStackLayout HorizontalOptions="Center">
             <Label Text="SnapPointsType: "
                    VerticalTextAlignment="Center" />
             <controls:EnumPicker x:Name="snapPointsTypeEnumPicker"
                               EnumType="{x:Type SnapPointsType}"
                               SelectedIndex="0"
                               SelectedIndexChanged="OnSnapPointsTypeSelectedIndexChanged" />
-        </StackLayout>
-        <StackLayout Orientation="Horizontal"
-                     HorizontalOptions="Center"
-                     Grid.Row="1">
+        </HorizontalStackLayout>
+        <HorizontalStackLayout HorizontalOptions="Center"
+                               Grid.Row="1">
             <Label Text="SnapPointsAlignment: "
                    VerticalTextAlignment="Center" />
             <controls:EnumPicker x:Name="snapPointsAlignmentEnumPicker"
                              EnumType="{x:Type SnapPointsAlignment}"
                              SelectedIndex="0"
                              SelectedIndexChanged="OnSnapPointsAlignmentSelectedIndexChanged" />
-        </StackLayout>
+        </HorizontalStackLayout>
         <CollectionView x:Name="collectionView"
                         ItemsSource="{Binding Monkeys}"
                         Grid.Row="2">

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/SnapPoints/VerticalListSnapPointsPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/SnapPoints/VerticalListSnapPointsPage.xaml
@@ -4,7 +4,8 @@
              xmlns:controls="clr-namespace:CollectionViewDemos.Controls"
              x:Class="CollectionViewDemos.Views.VerticalListSnapPointsPage"
              Title="Vertical list (snap points)">
-    <StackLayout Margin="20">
+    <Grid RowDefinitions="Auto, Auto, *"
+          Margin="20">
         <StackLayout Orientation="Horizontal"
                      HorizontalOptions="Center">
             <Label Text="SnapPointsType: "
@@ -15,9 +16,9 @@
                               SelectedIndexChanged="OnSnapPointsTypeSelectedIndexChanged" />
         </StackLayout>
         <StackLayout Orientation="Horizontal"
-                     HorizontalOptions="Center">
-            <Label Grid.Row="1" 
-                   Text="SnapPointsAlignment: "
+                     HorizontalOptions="Center"
+                     Grid.Row="1">
+            <Label Text="SnapPointsAlignment: "
                    VerticalTextAlignment="Center" />
             <controls:EnumPicker x:Name="snapPointsAlignmentEnumPicker"
                              EnumType="{x:Type SnapPointsAlignment}"
@@ -25,7 +26,8 @@
                              SelectedIndexChanged="OnSnapPointsAlignmentSelectedIndexChanged" />
         </StackLayout>
         <CollectionView x:Name="collectionView"
-                        ItemsSource="{Binding Monkeys}">
+                        ItemsSource="{Binding Monkeys}"
+                        Grid.Row="2">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -54,5 +56,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Spacing/HorizontalGridSpacingPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Spacing/HorizontalGridSpacingPage.xaml
@@ -4,12 +4,14 @@
              xmlns:controls="clr-namespace:CollectionViewDemos.Controls"
              x:Class="CollectionViewDemos.Views.HorizontalGridSpacingPage"
              Title="Horizontal grid (spacing)">
-    <StackLayout Margin="20">
+    <Grid RowDefinitions="Auto, *" 
+          Margin="20">
         <controls:SpacingModifier CV="{x:Reference collectionView}"
                                   SpacingText="0,0" />
         <CollectionView x:Name="collectionView"
                         ItemsSource="{Binding Monkeys}"
-                        ItemsLayout="HorizontalGrid, 4">
+                        ItemsLayout="HorizontalGrid, 4"
+                        Grid.Row="1">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -40,5 +42,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Spacing/HorizontalListSpacingPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Spacing/HorizontalListSpacingPage.xaml
@@ -4,12 +4,14 @@
              xmlns:controls="clr-namespace:CollectionViewDemos.Controls"
              x:Class="CollectionViewDemos.Views.HorizontalListSpacingPage"
              Title="Horizontal list (spacing)">
-    <StackLayout Margin="20">
+    <Grid RowDefinitions="Auto, *" 
+          Margin="20">
         <controls:SpacingModifier CV="{x:Reference collectionView}"
                                   SpacingText="0" />
         <CollectionView x:Name="collectionView"
                         ItemsSource="{Binding Monkeys}"
-                        ItemsLayout="HorizontalList">
+                        ItemsLayout="HorizontalList"
+                        Grid.Row="1">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -40,5 +42,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Spacing/VerticalGridSpacingPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Spacing/VerticalGridSpacingPage.xaml
@@ -4,12 +4,14 @@
              xmlns:controls="clr-namespace:CollectionViewDemos.Controls"
              x:Class="CollectionViewDemos.Views.VerticalGridSpacingPage"
              Title="Vertical grid (spacing)">
-    <StackLayout Margin="20">
+    <Grid RowDefinitions="Auto, *" 
+          Margin="20">
         <controls:SpacingModifier CV="{x:Reference collectionView}" 
                                   SpacingText="0,0" />
         <CollectionView x:Name="collectionView"
                         ItemsSource="{Binding Monkeys}"
-                        ItemsLayout="VerticalGrid, 2">
+                        ItemsLayout="VerticalGrid, 2"
+                        Grid.Row="1">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -40,5 +42,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Spacing/VerticalListSpacingPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Spacing/VerticalListSpacingPage.xaml
@@ -4,11 +4,13 @@
              xmlns:controls="clr-namespace:CollectionViewDemos.Controls"
              x:Class="CollectionViewDemos.Views.VerticalListSpacingPage"
              Title="Vertical list (spacing)">
-    <StackLayout Margin="20">
+    <Grid RowDefinitions="Auto, *" 
+          Margin="20">
         <controls:SpacingModifier CV="{x:Reference collectionView}"
                                   SpacingText="0" />
         <CollectionView x:Name="collectionView"
-                        ItemsSource="{Binding Monkeys}">
+                        ItemsSource="{Binding Monkeys}"
+                        Grid.Row="1">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
@@ -37,5 +39,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Swipe/VerticalListSwipeContextItemsPage.xaml
+++ b/8.0/UserInterface/Views/CollectionViewDemos/CollectionViewDemos/Views/Swipe/VerticalListSwipeContextItemsPage.xaml
@@ -4,7 +4,7 @@
              xmlns:viewmodels="clr-namespace:CollectionViewDemos.ViewModels"
              x:Class="CollectionViewDemos.Views.VerticalListSwipeContextItemsPage"
              Title="Context menu items">
-    <StackLayout Margin="20">
+    <Grid Margin="20">
         <CollectionView x:Name="collectionView"
                         ItemsSource="{Binding Monkeys}">
             <CollectionView.ItemTemplate>
@@ -52,5 +52,5 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
-    </StackLayout>
+    </Grid>
 </ContentPage>


### PR DESCRIPTION
Fixes #488.  Fixes #301.
Scrolling is not working for all `CollectionView`s inside `StackLayout` in CollectionViewDemos app.

Similar to the previous PR (#516), this PR replaces the SL with Grid in CollectionViewDemos app to fix this issue.

---
[Associated WorkItem - 320952](https://dev.azure.com/msft-skilling/Content/_workitems/edit/320952)