### PR TITLE
Move DataTemplateSelector to separate file for Developer Balance

### DIFF
--- a/9.0/Apps/DeveloperBalance/DeveloperBalance/Pages/Controls/ChipDataTemplateSelector.cs
+++ b/9.0/Apps/DeveloperBalance/DeveloperBalance/Pages/Controls/ChipDataTemplateSelector.cs
@@ -1,0 +1,12 @@
+namespace DeveloperBalance.Pages.Controls;
+
+public class ChipDataTemplateSelector : DataTemplateSelector
+{
+	public required DataTemplate SelectedTagTemplate { get; set; }
+	public required DataTemplate NormalTagTemplate { get; set; }
+
+	protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+	{
+		return (item as Tag)?.IsSelected ?? false ? SelectedTagTemplate : NormalTagTemplate;
+	}
+}

--- a/9.0/Apps/DeveloperBalance/DeveloperBalance/Pages/Controls/ChipDataTemplateSelector.cs
+++ b/9.0/Apps/DeveloperBalance/DeveloperBalance/Pages/Controls/ChipDataTemplateSelector.cs
@@ -1,3 +1,5 @@
+using DeveloperBalance.Models;
+
 namespace DeveloperBalance.Pages.Controls;
 
 public class ChipDataTemplateSelector : DataTemplateSelector

--- a/9.0/Apps/DeveloperBalance/DeveloperBalance/Pages/ProjectDetailPage.xaml
+++ b/9.0/Apps/DeveloperBalance/DeveloperBalance/Pages/ProjectDetailPage.xaml
@@ -46,7 +46,7 @@
             </Border>
         </DataTemplate>
 
-        <pages:ChipDataTemplateSelector 
+        <controls:ChipDataTemplateSelector 
             x:Key="ChipDataTemplateSelector"
             NormalTagTemplate="{StaticResource NormalTagTemplate}"
             SelectedTagTemplate="{StaticResource SelectedTagTemplate}"/>

--- a/9.0/Apps/DeveloperBalance/DeveloperBalance/Pages/ProjectDetailPage.xaml.cs
+++ b/9.0/Apps/DeveloperBalance/DeveloperBalance/Pages/ProjectDetailPage.xaml.cs
@@ -11,14 +11,3 @@ public partial class ProjectDetailPage : ContentPage
 		BindingContext = model;
 	}
 }
-
-public class ChipDataTemplateSelector : DataTemplateSelector
-{
-	public required DataTemplate SelectedTagTemplate { get; set; }
-	public required DataTemplate NormalTagTemplate { get; set; }
-
-	protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
-	{
-		return (item as Tag)?.IsSelected ?? false ? SelectedTagTemplate : NormalTagTemplate;
-	}
-}


### PR DESCRIPTION
This is a bit better practice!

Coming through here: https://github.com/dotnet/maui/issues/25515

This change will also end up in the new .NET MAUI project template