### PR TITLE
Change the radial chart to doughnut chart

### DIFF
--- a/9.0/Apps/DeveloperBalance/Pages/Controls/CategoryChart.xaml
+++ b/9.0/Apps/DeveloperBalance/Pages/Controls/CategoryChart.xaml
@@ -30,11 +30,11 @@
                     ShowDataLabels="True"
                     EnableTooltip="False"
                     x:Name="doughnutSeries"
-                    Radius="{OnIdiom 0.7, Phone=0.6}"
+                    Radius="{OnIdiom 0.7, Phone=0.5}"
                     InnerRadius="0.7" >
                     <chart:DoughnutSeries.LabelTemplate>
                         <DataTemplate >
-                            <HorizontalStackLayout Spacing="5">
+                            <HorizontalStackLayout>
                                 <Label Text="{Binding Item.Title}" TextColor="{AppThemeBinding
                                     Light={StaticResource DarkOnLightBackground},
                                     Dark={StaticResource LightOnDarkBackground}}" FontSize="{OnIdiom 18, Phone=14}"/>
@@ -49,7 +49,7 @@
                     </chart:DoughnutSeries.LabelTemplate>
 
                     <chart:DoughnutSeries.DataLabelSettings>
-                        <chart:CircularDataLabelSettings LabelPosition="Outside" SmartLabelAlignment="Shift" UseSeriesPalette="True">
+                        <chart:CircularDataLabelSettings LabelPosition="Outside" SmartLabelAlignment="Shift">
                             <chart:CircularDataLabelSettings.ConnectorLineSettings>
                                 <chart:ConnectorLineStyle ConnectorType="Line" StrokeWidth="3" ></chart:ConnectorLineStyle>
                             </chart:CircularDataLabelSettings.ConnectorLineSettings>

--- a/9.0/Apps/DeveloperBalance/Pages/Controls/CategoryChart.xaml
+++ b/9.0/Apps/DeveloperBalance/Pages/Controls/CategoryChart.xaml
@@ -7,16 +7,14 @@
         xmlns:pageModels="clr-namespace:DeveloperBalance.PageModels"
         x:Class="DeveloperBalance.Pages.Controls.CategoryChart"
         HeightRequest="{OnIdiom 300, Phone=200}"
-        Margin="0, 12"
-        Style="{StaticResource CardStyle}"
-        x:DataType="pageModels:MainPageModel">
+        Style="{StaticResource CardStyle}">
     <shimmer:SfShimmer
         BackgroundColor="Transparent"
         VerticalOptions="FillAndExpand"
         IsActive ="{Binding IsBusy}">
         <shimmer:SfShimmer.CustomView>
             <Grid>
-                <BoxView 
+                <BoxView
                     CornerRadius="12"
                     VerticalOptions="FillAndExpand"
                     Style="{StaticResource ShimmerCustomViewStyle}"/>
@@ -24,27 +22,41 @@
         </shimmer:SfShimmer.CustomView>
         <shimmer:SfShimmer.Content>
             <chart:SfCircularChart x:Name="Chart">
-                <chart:SfCircularChart.Legend>
-                    <controls:LegendExt Placement="Right">
-                        <chart:ChartLegend.LabelStyle>
-                            <chart:ChartLegendLabelStyle 
-                                TextColor="{AppThemeBinding 
-                                Light={StaticResource DarkOnLightBackground},
-                                Dark={StaticResource LightOnDarkBackground}}" 
-                                Margin="5" 
-                                FontSize="18" />
-                        </chart:ChartLegend.LabelStyle>
-                    </controls:LegendExt>
-                </chart:SfCircularChart.Legend>
-                <chart:RadialBarSeries 
+                <chart:DoughnutSeries
                     ItemsSource="{Binding TodoCategoryData}"
                     PaletteBrushes="{Binding TodoCategoryColors}"
                     XBindingPath="Title"
-                    YBindingPath="Count" 
+                    YBindingPath="Count"
                     ShowDataLabels="True"
-                    EnableTooltip="True" 
-                    TrackFill="{AppThemeBinding Light={StaticResource LightBackground}, Dark={StaticResource DarkBackground}}"
-                    CapStyle = "BothCurve"/>
+                    EnableTooltip="False"
+                    x:Name="doughnutSeries"
+                    Radius="{OnIdiom 0.7, Phone=0.6}"
+                    InnerRadius="0.7" >
+                    <chart:DoughnutSeries.LabelTemplate>
+                        <DataTemplate >
+                            <HorizontalStackLayout Spacing="5">
+                                <Label Text="{Binding Item.Title}" TextColor="{AppThemeBinding
+                                    Light={StaticResource DarkOnLightBackground},
+                                    Dark={StaticResource LightOnDarkBackground}}" FontSize="{OnIdiom 18, Phone=14}"/>
+                                <Label Text=" : " TextColor="{AppThemeBinding
+                                    Light={StaticResource DarkOnLightBackground},
+                                    Dark={StaticResource LightOnDarkBackground}}" FontSize="{OnIdiom 18, Phone=14}"/>
+                                <Label Text="{Binding Item.Count}" TextColor="{AppThemeBinding
+                                    Light={StaticResource DarkOnLightBackground},
+                                    Dark={StaticResource LightOnDarkBackground}}" FontSize="{OnIdiom 18, Phone=14}"/>
+                            </HorizontalStackLayout>
+                        </DataTemplate>
+                    </chart:DoughnutSeries.LabelTemplate>
+
+                    <chart:DoughnutSeries.DataLabelSettings>
+                        <chart:CircularDataLabelSettings LabelPosition="Outside" SmartLabelAlignment="Shift" UseSeriesPalette="True">
+                            <chart:CircularDataLabelSettings.ConnectorLineSettings>
+                                <chart:ConnectorLineStyle ConnectorType="Line" StrokeWidth="3" ></chart:ConnectorLineStyle>
+                            </chart:CircularDataLabelSettings.ConnectorLineSettings>
+                        </chart:CircularDataLabelSettings>
+                    </chart:DoughnutSeries.DataLabelSettings>
+                </chart:DoughnutSeries>
+
             </chart:SfCircularChart>
         </shimmer:SfShimmer.Content>
     </shimmer:SfShimmer>

--- a/9.0/Apps/DeveloperBalance/Pages/MainPage.xaml
+++ b/9.0/Apps/DeveloperBalance/Pages/MainPage.xaml
@@ -35,6 +35,7 @@
             <pullToRefresh:SfPullToRefresh.PullableContent>
                 <ScrollView>
                     <VerticalStackLayout Spacing="{StaticResource LayoutSpacing}" Padding="{StaticResource LayoutPadding}">
+                        <Label Text="Task Categories" Style="{StaticResource Title2}"/>
                         <controls:CategoryChart />
                         <Label Text="Projects" Style="{StaticResource Title2}"/>
                         <ScrollView Orientation="Horizontal" Margin="-30,0">


### PR DESCRIPTION
This PR changes the Radial Chart to a Doughnut chart. With the Radial chart, there were limited options on how to make the chart's information fully accessible for users who are color-blind and who use a keyboard only.

With the new doughnut chart, the data labels show the category name and the value without needing tooltips or a legend.

## Original:
![image](https://github.com/user-attachments/assets/03dbb3b4-cc42-41f7-84cc-7302a60cc8e8)

# New:
![image](https://github.com/user-attachments/assets/578db48f-d3eb-42f8-a237-fa7eb5d3591f)

![image](https://github.com/user-attachments/assets/fec942fa-1b2b-46d5-8f21-cc6ae9bd73a5)

<img src="https://github.com/user-attachments/assets/c0b2a72e-f47c-45aa-9518-2d65987e6fbb" alt="description" height="500">


The only concern is that with these data labels on the mobile devices is if they are too long, they will not show up.



Adresses:
* https://github.com/dotnet/maui/issues/26232
* https://github.com/dotnet/maui/issues/26234
* https://github.com/dotnet/maui/issues/26236
