### PR TITLE
Revert Keyboard DeveloperAccessibility PRs

### DIFF
--- a/9.0/Apps/DeveloperBalance/Pages/MainPage.xaml
+++ b/9.0/Apps/DeveloperBalance/Pages/MainPage.xaml
@@ -38,24 +38,21 @@
                         <Label Text="Task Categories" Style="{StaticResource Title2}"/>
                         <controls:CategoryChart />
                         <Label Text="Projects" Style="{StaticResource Title2}"/>
-                        <CollectionView
-                            ItemsSource="{Binding Projects}"
-                            Margin="-15, 0">
-                            <CollectionView.ItemsLayout>
-                                <LinearItemsLayout                              
-                                    Orientation="Horizontal"
-                                    ItemSpacing="15" />
-                            </CollectionView.ItemsLayout>
-                            <CollectionView.ItemTemplate>
-                                <DataTemplate x:DataType="models:Project">
-                                    <controls:ProjectCardView WidthRequest="200">
-                                        <controls:ProjectCardView.GestureRecognizers>
-                                            <TapGestureRecognizer Command="{Binding NavigateToProjectCommand, Source={RelativeSource AncestorType={x:Type pageModels:MainPageModel}}, x:DataType=pageModels:MainPageModel}" CommandParameter="{Binding .}"/>
-                                        </controls:ProjectCardView.GestureRecognizers>
-                                    </controls:ProjectCardView>
-                                </DataTemplate>
-                            </CollectionView.ItemTemplate>
-                        </CollectionView>
+                        <ScrollView Orientation="Horizontal" Margin="-30,0">
+                            <HorizontalStackLayout 
+                                Spacing="15" Padding="30,0"
+                                BindableLayout.ItemsSource="{Binding Projects}">
+                                <BindableLayout.ItemTemplate>
+                                    <DataTemplate x:DataType="models:Project">
+                                        <controls:ProjectCardView WidthRequest="200">
+                                            <controls:ProjectCardView.GestureRecognizers>
+                                                <TapGestureRecognizer Command="{Binding NavigateToProjectCommand, Source={RelativeSource AncestorType={x:Type pageModels:MainPageModel}}, x:DataType=pageModels:MainPageModel}" CommandParameter="{Binding .}"/>
+                                            </controls:ProjectCardView.GestureRecognizers>
+                                        </controls:ProjectCardView>
+                                    </DataTemplate>
+                                </BindableLayout.ItemTemplate>
+                            </HorizontalStackLayout>
+                        </ScrollView>
                         <Grid HeightRequest="44">
                             <Label Text="Tasks" Style="{StaticResource Title2}" VerticalOptions="Center"/>
                             <ImageButton 

--- a/9.0/Apps/DeveloperBalance/Pages/ProjectListPage.xaml
+++ b/9.0/Apps/DeveloperBalance/Pages/ProjectListPage.xaml
@@ -17,15 +17,11 @@
     </ContentPage.Behaviors>
     <Grid>
       <ScrollView>
-        <CollectionView 
-            ItemsSource="{Binding Projects}" 
-            Margin="{StaticResource LayoutPadding}">
-            <CollectionView.ItemsLayout>
-                <LinearItemsLayout 
-                    Orientation="Vertical"
-                    ItemSpacing="{StaticResource LayoutSpacing}"/>
-            </CollectionView.ItemsLayout>
-            <CollectionView.ItemTemplate>
+        <VerticalStackLayout 
+            BindableLayout.ItemsSource="{Binding Projects}" 
+            Margin="{StaticResource LayoutPadding}" 
+            Spacing="{StaticResource LayoutSpacing}">
+            <BindableLayout.ItemTemplate>
                 <DataTemplate x:DataType="models:Project">
                     <Border>
                         <VerticalStackLayout Padding="10">
@@ -37,8 +33,8 @@
                         </Border.GestureRecognizers>
                     </Border>
                 </DataTemplate>
-            </CollectionView.ItemTemplate>
-        </CollectionView>
+            </BindableLayout.ItemTemplate>
+        </VerticalStackLayout>
       </ScrollView>
 
         <controls:AddButton 


### PR DESCRIPTION
As mentioned in this PR: https://github.com/dotnet/maui/pull/27322

These appears to be a [bug](https://github.com/dotnet/maui/issues/27325) with CollectionView2 when trying to use these changes in our template. For the time being, we should keep the BindableLayout and make the BindableLayout more accessible for keyboard users.

This PR reverts https://github.com/dotnet/maui-samples/pull/573  and  https://github.com/dotnet/maui-samples/pull/572