### PR TITLE
Adding VisualStateGroupList for Switch Visual State examples

### DIFF
--- a/8.0/UserInterface/Views/SwitchDemos/SwitchDemos/Views/SwitchVisualStatesPage.xaml
+++ b/8.0/UserInterface/Views/SwitchDemos/SwitchDemos/Views/SwitchVisualStatesPage.xaml
@@ -25,20 +25,22 @@
                 IsToggled="True"
                 HorizontalOptions="End">
             <VisualStateManager.VisualStateGroups>
-                <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="On">
-                        <VisualState.Setters>
-                            <Setter Property="ThumbColor"
-                                    Value="MediumSpringGreen" />
-                        </VisualState.Setters>
-                    </VisualState>
-                    <VisualState x:Name="Off">
-                        <VisualState.Setters>
-                            <Setter Property="ThumbColor"
-                                    Value="Red" />
-                        </VisualState.Setters>
-                    </VisualState>
-                </VisualStateGroup>
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="On">
+                            <VisualState.Setters>
+                                <Setter Property="ThumbColor"
+                                        Value="MediumSpringGreen" />
+                            </VisualState.Setters>
+                        </VisualState>
+                        <VisualState x:Name="Off">
+                            <VisualState.Setters>
+                                <Setter Property="ThumbColor"
+                                        Value="Red" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
             </VisualStateManager.VisualStateGroups>
         </Switch>
     </Grid>

--- a/9.0/UserInterface/Views/SwitchDemos/SwitchDemos/Views/SwitchVisualStatesPage.xaml
+++ b/9.0/UserInterface/Views/SwitchDemos/SwitchDemos/Views/SwitchVisualStatesPage.xaml
@@ -25,20 +25,22 @@
                 IsToggled="True"
                 HorizontalOptions="End">
             <VisualStateManager.VisualStateGroups>
-                <VisualStateGroup x:Name="CommonStates">
-                    <VisualState x:Name="On">
-                        <VisualState.Setters>
-                            <Setter Property="ThumbColor"
-                                    Value="MediumSpringGreen" />
-                        </VisualState.Setters>
-                    </VisualState>
-                    <VisualState x:Name="Off">
-                        <VisualState.Setters>
-                            <Setter Property="ThumbColor"
-                                    Value="Red" />
-                        </VisualState.Setters>
-                    </VisualState>
-                </VisualStateGroup>
+                <VisualStateGroupList>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="On">
+                            <VisualState.Setters>
+                                <Setter Property="ThumbColor"
+                                        Value="MediumSpringGreen" />
+                            </VisualState.Setters>
+                        </VisualState>
+                        <VisualState x:Name="Off">
+                            <VisualState.Setters>
+                                <Setter Property="ThumbColor"
+                                        Value="Red" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
             </VisualStateManager.VisualStateGroups>
         </Switch>
     </Grid>


### PR DESCRIPTION
As discussed [here](https://github.com/dotnet/docs-maui/pull/2765).  It's ideal to use `VisualStateGroupList` whenever we are defining our own Visual states. Since default MAUI template comes with defined style for Switch.