### PR TITLE
HybridWebView: serialize all return values

### DIFF
--- a/9.0/UserInterface/Views/HybridWebViewDemo/HybridWebViewDemo/Resources/Raw/wwwroot/scripts/HybridWebView.js
+++ b/9.0/UserInterface/Views/HybridWebViewDemo/HybridWebViewDemo/Resources/Raw/wwwroot/scripts/HybridWebView.js
@@ -108,12 +108,8 @@
     },
 
     "__TriggerAsyncCallback": function __TriggerAsyncCallback(taskId, result) {
-        // Make sure the result is a string
-        if (result && typeof (result) !== 'string') {
-            result = JSON.stringify(result);
-        }
-
-        window.HybridWebView.__SendMessageInternal('__InvokeJavaScriptCompleted', taskId + '|' + result);
+        const json = JSON.stringify(result);
+        window.HybridWebView.__SendMessageInternal('__InvokeJavaScriptCompleted', taskId + '|' + json);
     }
 }
 


### PR DESCRIPTION
In .NET (MAUI) 9 SR4 it's necessary to serialise all return values. Previously, strings were a special case.