### PR TITLE
Update .NET MAUI Community Toolkit reference in Developer Balance app

### DIFF
--- a/9.0/Apps/DeveloperBalance/DeveloperBalance.csproj
+++ b/9.0/Apps/DeveloperBalance/DeveloperBalance.csproj
@@ -69,7 +69,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
-		<PackageReference Include="CommunityToolkit.Maui" Version="9.1.1" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="11.1.0" />
 		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.8" />
 		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
 		<PackageReference Include="Syncfusion.Maui.Toolkit" Version="1.0.3" />

--- a/9.0/Apps/DeveloperBalance/DeveloperBalance.csproj
+++ b/9.0/Apps/DeveloperBalance/DeveloperBalance.csproj
@@ -19,8 +19,6 @@
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<!-- https://github.com/CommunityToolkit/Maui/issues/2205 -->
-		<NoWarn>XC0103</NoWarn>
 		<MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
 
 		<!-- Display name -->

--- a/9.0/Apps/DeveloperBalance/DeveloperBalance.csproj
+++ b/9.0/Apps/DeveloperBalance/DeveloperBalance.csproj
@@ -19,7 +19,6 @@
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
 
 		<!-- Display name -->
 		<ApplicationTitle>DeveloperBalance</ApplicationTitle>
@@ -61,7 +60,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.40" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
 	</ItemGroup>
 

--- a/9.0/Apps/DeveloperBalance/Pages/ManageMetaPage.xaml
+++ b/9.0/Apps/DeveloperBalance/Pages/ManageMetaPage.xaml
@@ -61,7 +61,7 @@
                                 <Entry.Behaviors>
                                     <toolkit:TextValidationBehavior 
                                         InvalidStyle="{StaticResource InvalidEntryStyle}"
-                                        Flags="ValidateOnUnfocusing"
+                                        Flags="ValidateOnUnfocused"
                                         RegexPattern="^#(?:[0-9a-fA-F]{3}){1,2}$" />
                                 </Entry.Behaviors>
                             </Entry>

--- a/9.0/Apps/DeveloperBalance/Pages/ManageMetaPage.xaml
+++ b/9.0/Apps/DeveloperBalance/Pages/ManageMetaPage.xaml
@@ -104,7 +104,7 @@
                                 <Entry.Behaviors>
                                     <toolkit:TextValidationBehavior 
                                         InvalidStyle="{StaticResource InvalidEntryStyle}"
-                                        Flags="ValidateOnUnfocusing"
+                                        Flags="ValidateOnUnfocused"
                                         RegexPattern="^#(?:[0-9a-fA-F]{3}){1,2}$" />
                                 </Entry.Behaviors>
                             </Entry>


### PR DESCRIPTION
### Description of Change

Updating the .NET MAUI Community Toolkit reference to 11.1.0 and updating the sample data template we use the TextValidationBehavior, and set the Flags property to influence when the behavior should kick in.

The value is used to be ValidateOnUnfocused, and is now renamed to ValidateOnUnfocusing. See: https://github.com/CommunityToolkit/Maui/blob/0a4dd43e14c07c4df6ed2241ac600d5f972f90f9/src/CommunityToolkit.Maui/Behaviors/Validators/ValidationBehavior.shared.cs#L19

It was renamed in this PR: https://github.com/CommunityToolkit/Maui/pull/2215

Also see the .NET MAUI Template PR: https://github.com/dotnet/maui/pull/28061