### PR TITLE
TJ Feb ScoreCard Day

### DIFF
--- a/9.0/UserInterface/Views/TableViewDemos/TableViewDemos/Views/DataIntentPage.xaml
+++ b/9.0/UserInterface/Views/TableViewDemos/TableViewDemos/Views/DataIntentPage.xaml
@@ -3,30 +3,54 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
              x:Class="TableViewDemos.DataIntentPage" 
              Title="Data page">
-    <TableView Intent="Data" 
-               HasUnevenRows="true" >
-        <TableRoot>
-            <TableSection>
-                <TextCell Text="This TableView uses the data intent." 
-                          Detail="However, data is often better presented in a ListView." />
-                <ImageCell Text="Images can also be displayed."
-                           Detail="HasUnevenRows is set to true."
-                           ImageSource="dotnet_bot.png" />
-                <ViewCell x:Name="viewCell" 
-                          Tapped="OnViewCellTapped">
-                    <Grid Margin="15,0">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
-                        <Label Text="Tap this cell." />
-                        <Label x:Name="target" 
-                               Grid.Row="1"
-                               Text="The cell has changed size." 
-                               IsVisible="false" />
-                    </Grid>
-                </ViewCell>
-            </TableSection>
-        </TableRoot>
-    </TableView>
+    <CollectionView x:Name="collectionView" 
+                   SelectionMode="None">
+        <CollectionView.ItemTemplate>
+            <DataTemplate>
+                <Grid Padding="15" x:Name="itemGrid">
+                    <Border StrokeThickness="1"
+                            Stroke="LightGray"
+                            StrokeShape="RoundRectangle 5"
+                            Padding="10">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            
+                            <Image Grid.RowSpan="2" 
+                                   Source="{Binding ImageSource}" 
+                                   HeightRequest="60" 
+                                   WidthRequest="60"
+                                   IsVisible="{Binding HasImage}"/>
+                            
+                            <Label Grid.Column="1" 
+                                   Text="{Binding Text}" 
+                                   FontAttributes="Bold"/>
+                            
+                            <Label Grid.Column="1"
+                                   Grid.Row="1"
+                                   Text="{Binding Detail}"
+                                   IsVisible="{Binding HasDetail}"/>
+                            
+                            <Label Grid.Column="{Binding ExtraTextColumn}"
+                                   Grid.Row="2"
+                                   Text="{Binding ExtraText}"
+                                   IsVisible="{Binding IsExpanded}"/>
+                            
+                            <Grid.GestureRecognizers>
+                                <TapGestureRecognizer Command="{Binding Source={x:Reference collectionView}, Path=BindingContext.ToggleExpandCommand}"
+                                                      CommandParameter="{Binding .}"/>
+                            </Grid.GestureRecognizers>
+                        </Grid>
+                    </Border>
+                </Grid>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+    </CollectionView>
 </ContentPage>

--- a/9.0/UserInterface/Views/TableViewDemos/TableViewDemos/Views/DataIntentPage.xaml.cs
+++ b/9.0/UserInterface/Views/TableViewDemos/TableViewDemos/Views/DataIntentPage.xaml.cs
@@ -1,16 +1,66 @@
-﻿namespace TableViewDemos
-{
-	public partial class DataIntentPage : ContentPage
-	{
-		public DataIntentPage ()
-		{
-			InitializeComponent ();
-		}
+﻿using System.Collections.ObjectModel;
+using System.Windows.Input;
 
-        void OnViewCellTapped(object sender, EventArgs e)
+namespace TableViewDemos
+{
+    public partial class DataIntentPage : ContentPage
+    {
+        public ObservableCollection<DataItem> Items { get; set; }
+        public ICommand ToggleExpandCommand { get; private set; }
+
+        public DataIntentPage()
         {
-            target.IsVisible = !target.IsVisible;
-            viewCell.ForceUpdateSize();
+            InitializeComponent();
+
+            // Initialize data items
+            Items = new ObservableCollection<DataItem>
+            {
+                new DataItem 
+                { 
+                    Text = "This TableView uses the data intent.",
+                    Detail = "However, data is often better presented in a ListView.",
+                    HasDetail = true
+                },
+                new DataItem 
+                { 
+                    Text = "Images can also be displayed.",
+                    Detail = "HasUnevenRows is set to true.",
+                    HasDetail = true,
+                    HasImage = true,
+                    ImageSource = "dotnet_bot.png"
+                },
+                new DataItem 
+                { 
+                    Text = "Tap this cell.",
+                    ExtraText = "The cell has changed size.",
+                    HasDetail = false
+                }
+            };
+
+            // Command to handle item tapping
+            ToggleExpandCommand = new Command<DataItem>(item =>
+            {
+                if (item.Text == "Tap this cell.")
+                {
+                    item.IsExpanded = !item.IsExpanded;
+                }
+            });
+
+            // Set the binding context
+            BindingContext = this;
+            collectionView.ItemsSource = Items;
         }
-	}
+    }
+
+    public class DataItem
+    {
+        public string Text { get; set; }
+        public string Detail { get; set; }
+        public bool HasDetail { get; set; }
+        public string ImageSource { get; set; }
+        public bool HasImage { get; set; }
+        public string ExtraText { get; set; }
+        public bool IsExpanded { get; set; }
+        public int ExtraTextColumn => HasImage ? 1 : 0;
+    }
 }

--- a/9.0/UserInterface/Views/TableViewDemos/TableViewDemos/Views/MainPage.xaml
+++ b/9.0/UserInterface/Views/TableViewDemos/TableViewDemos/Views/MainPage.xaml
@@ -5,28 +5,23 @@
              x:Class="TableViewDemos.MainPage"
              Title="TableView demos"
              x:DataType="local:MainPage">
-    <TableView Intent="Menu">
-        <TableRoot>
-            <TableSection Title="Basics">
-                <TextCell Text="Menu page"
-                          Command="{Binding NavigateCommand}"
-                          CommandParameter="{x:Type views:MenuIntentPage}" />
-                <TextCell Text="Settings page"
-                          Command="{Binding NavigateCommand}"
-                          CommandParameter="{x:Type views:SettingsIntentPage}" />
-                <TextCell Text="Form page"
-                          Command="{Binding NavigateCommand}"
-                          CommandParameter="{x:Type views:FormIntentPage}" />
-                <TextCell Text="Data page"
-                          Command="{Binding NavigateCommand}"
-                          CommandParameter="{x:Type views:DataIntentPage}" />
-                <TextCell Text="ImageCell page"
-                          Command="{Binding NavigateCommand}"
-                          CommandParameter="{x:Type views:ImageCellPage}" />
-                <TextCell Text="Right to left TableView"
-                          Command="{Binding NavigateCommand}"
-                          CommandParameter="{x:Type views:RightToLeftTablePage}" />
-            </TableSection>
-        </TableRoot>
-    </TableView>
+    <Grid RowDefinitions="Auto,*" Padding="10">
+        <Label Text="Basics" FontAttributes="Bold" FontSize="Large" Margin="10,0,0,5"/>
+        <CollectionView Grid.Row="1" ItemsSource="{Binding MenuItems}">
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="local:MenuItem">
+                    <Frame Margin="2" Padding="10" BorderColor="LightGray">
+                        <Frame.GestureRecognizers>
+                            <TapGestureRecognizer 
+                                Command="{Binding Source={RelativeSource AncestorType={x:Type local:MainPage}}, Path=NavigateCommand}" 
+                                CommandParameter="{Binding PageType}" />
+                        </Frame.GestureRecognizers>
+                        <Label Text="{Binding Title}" 
+                               FontSize="Medium" 
+                               VerticalOptions="Center" />
+                    </Frame>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </Grid>
 </ContentPage>

--- a/9.0/UserInterface/Views/TableViewDemos/TableViewDemos/Views/MainPage.xaml.cs
+++ b/9.0/UserInterface/Views/TableViewDemos/TableViewDemos/Views/MainPage.xaml.cs
@@ -1,10 +1,12 @@
 ﻿using System.Windows.Input;
+using System.Collections.ObjectModel;
 
 namespace TableViewDemos;
 
 public partial class MainPage : ContentPage
 {
 	public ICommand NavigateCommand { get; private set; }
+	public ObservableCollection<MenuItem> MenuItems { get; } = new ObservableCollection<MenuItem>();
 
 	public MainPage()
 	{
@@ -16,6 +18,22 @@ public partial class MainPage : ContentPage
 				Page page = (Page)Activator.CreateInstance(pageType);
 				await Navigation.PushAsync(page);
 			});
+			
+		// Populate menu items
+		MenuItems.Add(new MenuItem { Title = "Menu page", PageType = typeof(MenuIntentPage) });
+		MenuItems.Add(new MenuItem { Title = "Settings page", PageType = typeof(SettingsIntentPage) });
+		MenuItems.Add(new MenuItem { Title = "Form page", PageType = typeof(FormIntentPage) });
+		MenuItems.Add(new MenuItem { Title = "Data page", PageType = typeof(DataIntentPage) });
+		MenuItems.Add(new MenuItem { Title = "ImageCell page", PageType = typeof(ImageCellPage) });
+		MenuItems.Add(new MenuItem { Title = "Right to left TableView", PageType = typeof(RightToLeftTablePage) });
+		
 		BindingContext = this;
 	}
+}
+
+// Data model for menu items
+public class MenuItem
+{
+	public string Title { get; set; }
+	public Type PageType { get; set; }
 }


### PR DESCRIPTION
For Feb ScoreCard Day, I played around with AI to change the TableViewDemos repo to use CollectionViews.
I used VSCode on Mac (and later VSCode Insiders).

### Debugging
I had issues with Hot Reload in the past (1.5 months ago) so I turned it off. I enabled all the Hot Reload settings today and was very surprised how quickly the xaml hot reload fired. I didn't even have to save the changes and saw it updating text in real time which was fun to see.

### Changing to CollectionViews

#### VSCode CoPilot
I started this task with VSCode copilot. I highlighted the mainpage.xaml and pasted in the mainpage.xaml.cs and instructed copilot to change this to a CollectionView. It gave me some changes for both files that did not compile. It successfully changed the TableView to a CollectionView, but the content of the new CollectionView was a TextCell and it was not successful in fixing this error after asking it more about it. After that, there were issues with the Binding for the command that copilot was not able to fix.

#### ChatGPT
Using GPT-4 Turbo, I pasted my mainpage.xaml and my mainpage.xaml.cs file and asked it to change the tableview to a collectionview. I loved the presentation of the changes with the colors and grouping and made it a lot easier to digest. I know that the vscode copilot has a significant less amount of real estate though but that was my initial reaction. 

<img src="https://github.com/user-attachments/assets/97f7b5c6-1f34-4674-905a-fa1fdab08cbc" height="400" />

It gave me two solutions, the first was a solution that involved a SwipeView on the CollectionView and I have no idea why it tried to add that. The second solution was considered a 'simplified' version that was pretty much what copilot offered me but had a label inside instead of a TextCell.

However, with the code it gave me, the CollectionView did not show anything with either solution. After asking it a few times, it did not come up with an answer why. The Binding Context for the CollectionView's DataTemplate was not correct.

#### CoPilot Agentic Mode
I had not heard of the Agentic Mode before and my first impression of it is that it is spectacular. I did the same thing as the two previous chats where I gave it the mainpage.xaml and the mainpage.xaml.cs. It did the same thing that vscode copilot did where it created a CollectionView with a TextCell inside - incorrect. It makes sense though since I was pretty much doing the same exact thing. I did change the model from GPT-4o to Claude 3.7 Sonnet and that was a game changer. On the first try, it successfully changed the mainpage.xaml and the mainpage.xaml.cs to a CollectionView that worked on the first build. I was so blown away by this I just threw in the whole project and said to change every TableView to a CollectionView. This didn't work and created a bunch of errors.

It created some ViewModel files that were formatted very strangely. I was able to pass in the errors and told it fix them for about 5 passes and it didn't really solve any issues. I noticed that it was using Frames and it was not using Shadows on Borders correctly. It also seemed to be getting confused on Namespaces.

I undid all those changes and just went to another tableview with just the xaml and the xaml.cs file and it mostly was able to change that one without any issues.


### Takeaways
Overall, this was a cool experiment and was a great introduction to Agentic Mode. As I type this out, I also see that I can use agentic mode inside the normal vscode that I have and can change the model which I had never tried. I will definitely play around more with other models like Claude going forward as well.

