### PR TITLE
Fix ListView demo navigation issue after back navigation

### DIFF
--- a/8.0/UserInterface/Views/ListViewDemos/ListViewDemos/Views/MainPage.xaml.cs
+++ b/8.0/UserInterface/Views/ListViewDemos/ListViewDemos/Views/MainPage.xaml.cs
@@ -18,5 +18,14 @@ public partial class MainPage : ContentPage
 			});
 		BindingContext = this;
 	}
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        // Force refresh the bindings to avoid stale command issues after back navigation
+        BindingContext = null;
+        BindingContext = this;
+    }
+
 }
 


### PR DESCRIPTION
## Problem

In the ListViewDemos sample (under 8.0 -> Views -> ListViewDemos), navigation using TextCell items stops working after returning from a detail page using the back arrow. 

Although the BindingContext remains set, the commands on TextCells stop responding after navigating back.

## Solution

In `MainPage.xaml.cs`, I added a workaround that forces the page to refresh its bindings when it becomes visible again:


`protected override void OnAppearing()
{
    base.OnAppearing();
    BindingContext = null;
    BindingContext = this;
}`