### PR TITLE
Fix GH Actions build

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -16,10 +16,14 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Install .NET 9
+    - name: Install .NET SDKs
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0
+        dotnet-version: |
+          8.0.x
+          9.0.x
+          10.0.x
+        include-prerelease: true
 
     - name: Install .NET MAUI Workload
       run: dotnet workload install maui

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -20,10 +20,14 @@ jobs:
       with:
         fetch-depth: 2
 
-    - name: Install .NET 9
+    - name: Install .NET SDKs
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0
+        dotnet-version: |
+          8.0.x
+          9.0.x
+          10.0.x
+        include-prerelease: true
 
     - name: Install .NET MAUI Workload
       run: dotnet workload install maui
@@ -35,6 +39,7 @@ jobs:
     - name: Find and build changed projects
       run: |
         $failedProjectCount=0
+        $skippedProjectCount=0
         # Get the list of changed files
         $changedFiles = git diff --name-only -r --diff-filter=d HEAD^1 HEAD
 


### PR DESCRIPTION
closes: internal

This pull request updates the GitHub Actions workflows to support multiple .NET SDK versions and improves the build process by introducing a new variable to track skipped projects. Below are the key changes grouped by theme:

### Workflow Updates for .NET SDKs:
* [`.github/workflows/build-all.yml`](diffhunk://#diff-7682a9fd2942d8a81f55c30abd512b277b1b1eb7c5f16b2c4d88323de90e55d0L19-R26): Updated the `.NET SDK` installation step to support versions `8.0.x`, `9.0.x`, and `10.0.x`, including prerelease versions. The step name was also updated to reflect this change.
* [`.github/workflows/build-pr.yml`](diffhunk://#diff-15b4de36ac797b24d56f24c4403e979f20eabd06c3d49f3ffdceb0ebec3c0fb2L23-R30): Made the same updates as in `build-all.yml` to support multiple .NET SDK versions and include prerelease versions.

### Build Process Improvements:
* [`.github/workflows/build-pr.yml`](diffhunk://#diff-15b4de36ac797b24d56f24c4403e979f20eabd06c3d49f3ffdceb0ebec3c0fb2R42): Added a new variable `$skippedProjectCount` to the "Find and build changed projects" step, presumably to track projects that are skipped during the build process.