### PR TITLE
Apply fixes for the DeveloperBalance App

### DIFF
--- a/10.0/Apps/DeveloperBalance/Pages/Controls/TaskView.xaml
+++ b/10.0/Apps/DeveloperBalance/Pages/Controls/TaskView.xaml
@@ -53,7 +53,14 @@
                         Text="{Binding Title}"
                         VerticalOptions="Center"
                         LineBreakMode="WordWrap"
-                        AutomationProperties.IsInAccessibleTree="False" />
+                        AutomationProperties.IsInAccessibleTree="False">
+                        <Label.Margin>
+                            <OnPlatform x:TypeArguments="Thickness">
+                                <On Platform="iOS, MacCatalyst" Value="0, 0, 0, 6"/>
+                                <On Platform="Default"     Value="0"/>
+                            </OnPlatform>
+                        </Label.Margin>
+                    </Label>
                 </Grid>
             </shimmer:SfShimmer.Content>
         </shimmer:SfShimmer>

--- a/9.0/Apps/DeveloperBalance/Converters/SelectionChangedEventArgsConverter.cs
+++ b/9.0/Apps/DeveloperBalance/Converters/SelectionChangedEventArgsConverter.cs
@@ -1,0 +1,14 @@
+using System.Globalization;
+using CommunityToolkit.Maui.Converters;
+
+namespace DeveloperBalance.Converters;
+
+public class SelectionChangedEventArgsConverter: BaseConverterOneWay<SelectionChangedEventArgs?, object?>
+{
+    public override object? ConvertFrom(SelectionChangedEventArgs? value, CultureInfo? culture)
+    {
+        return value;
+    }
+
+    public override object? DefaultConvertReturnValue { get; set; } = null;
+}

--- a/9.0/Apps/DeveloperBalance/PageModels/ProjectDetailPageModel.cs
+++ b/9.0/Apps/DeveloperBalance/PageModels/ProjectDetailPageModel.cs
@@ -282,17 +282,20 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 	}
 
 	[RelayCommand]
-	private async Task SelectionChanged(object parameter)
+	private async Task SelectionChanged(SelectionChangedEventArgs parameter)
 	{
-		if (parameter is IEnumerable<object> enumerableParameter)
+		var cur = parameter.CurrentSelection;
+		var prev = parameter.PreviousSelection;
+
+		var changedTag = cur.Except(prev).ToList();
+		if (changedTag.Count == 0)
 		{
-			var changed = enumerableParameter.OfType<Tag>().ToList();
+			changedTag = prev.Except(cur).ToList();
+		}
 
-			if (changed.Count == 0 && SelectedTags is not null)
-				changed = SelectedTags.OfType<Tag>().Except(enumerableParameter.OfType<Tag>()).ToList();
-
-			if (changed.Count == 1)
-				await ToggleTag(changed[0]);
+		if (changedTag.Count == 1 && changedTag[0] is Tag tag)
+		{
+			await ToggleTag(tag);
 		}
 	}
 }

--- a/9.0/Apps/DeveloperBalance/Pages/Controls/TaskView.xaml
+++ b/9.0/Apps/DeveloperBalance/Pages/Controls/TaskView.xaml
@@ -39,11 +39,20 @@
 
                     <Grid SemanticProperties.Description="{Binding Title}" Margin="{OnIdiom -15, Desktop=-20}">
                         <Label
-                            Margin="{OnIdiom '65,0,0,0', Desktop= '70,0,0,0'}"
                             Text="{Binding Title}"
                             HorizontalOptions="Start"
                             VerticalOptions="Center"
-                            LineBreakMode="WordWrap"/>
+                            LineBreakMode="WordWrap">
+                            <Label.Margin>
+                                <OnPlatform x:TypeArguments="Thickness">
+                                    <On Platform="iOS" Value="65,0,0,6"/>
+                                    <On Platform="MacCatalyst" Value="70,0,0,6"/>
+                                    <On Platform="Android" Value="65,0,0,0"/>
+                                    <On Platform="WinUI" Value="70,0,0,0"/>
+                                    <On Platform="Default" Value="65,0,0,0"/>
+                                </OnPlatform>
+                            </Label.Margin>
+                        </Label>
 
                         <Grid.GestureRecognizers>
                             <TapGestureRecognizer

--- a/9.0/Apps/DeveloperBalance/Pages/ProjectDetailPage.xaml
+++ b/9.0/Apps/DeveloperBalance/Pages/ProjectDetailPage.xaml
@@ -5,12 +5,19 @@
              xmlns:models="clr-namespace:DeveloperBalance.Models"
              xmlns:pages="clr-namespace:DeveloperBalance.Pages"
              xmlns:sf="clr-namespace:Syncfusion.Maui.Toolkit.TextInputLayout;assembly=Syncfusion.Maui.Toolkit"
+             xmlns:converters="clr-namespace:DeveloperBalance.Converters"
              xmlns:controls="clr-namespace:DeveloperBalance.Pages.Controls"
              xmlns:fonts="clr-namespace:Fonts"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              x:Class="DeveloperBalance.Pages.ProjectDetailPage"
              x:DataType="pageModels:ProjectDetailPageModel"
+             x:Name="DetailsPage"
              Title="Project">
-
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <converters:SelectionChangedEventArgsConverter x:Key="SelectionChangedEventArgsConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
     <ContentPage.ToolbarItems>
         <ToolbarItem
             Text="Delete"
@@ -106,9 +113,14 @@
                     HeightRequest="44"
                     Margin="0,0,0,15"
                     SelectedItems="{Binding SelectedTags, Mode=TwoWay}"
-                    SelectionChangedCommand="{Binding SelectionChangedCommand}"
-                    SelectionChangedCommandParameter="{Binding SelectedTags}"
                     SemanticProperties.Description="Tags Collection">
+                    <CollectionView.Behaviors>
+                        <toolkit:EventToCommandBehavior
+                            BindingContext="{Binding Path=BindingContext, Source={x:Reference DetailsPage}, x:DataType=ContentPage}"
+                            EventName="SelectionChanged"
+                            EventArgsConverter="{StaticResource SelectionChangedEventArgsConverter}"
+                            Command="{Binding SelectionChangedCommand}" />
+                    </CollectionView.Behaviors>
                     <CollectionView.ItemsLayout>
                         <LinearItemsLayout Orientation="Horizontal" ItemSpacing="{StaticResource LayoutSpacing}" />
                     </CollectionView.ItemsLayout>


### PR DESCRIPTION
Apply fixes for the DeveloperBalance App:
- When creating a new project and adding two or more tags, the tags are not properly updated. Initially, only one tag is added and the other tags are not displayed. Fixed.
- Fix a shimmer continuously loading state if edit the project and back.
- RadioButton text alignment issues on iOS and Catalyst.