### PR TITLE
Fixed Delete Button Visibility When Creating a New Project

### DIFF
--- a/10.0/Apps/DeveloperBalance/PageModels/ProjectDetailPageModel.cs
+++ b/10.0/Apps/DeveloperBalance/PageModels/ProjectDetailPageModel.cs
@@ -52,7 +52,19 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 		new IconData { Icon = FluentUI.bot_24_regular, Description = "Bot Icon" }
 	};
 
-	public bool HasCompletedTasks
+	private bool _canDelete;
+
+	public bool CanDelete
+	{
+		get => _canDelete;
+		set
+		{
+			_canDelete = value;
+			DeleteCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    public bool HasCompletedTasks
 		=> _project?.Tasks.Any(t => t.IsCompleted) ?? false;
 
 	public ProjectDetailPageModel(ProjectRepository projectRepository, TaskRepository taskRepository, CategoryRepository categoryRepository, TagRepository tagRepository, ModalErrorHandler errorHandler)
@@ -145,7 +157,8 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 		finally
 		{
 			IsBusy = false;
-			OnPropertyChanged(nameof(HasCompletedTasks));
+			CanDelete = !_project.IsNullOrNew();
+            OnPropertyChanged(nameof(HasCompletedTasks));
 		}
 	}
 
@@ -216,7 +229,7 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 			});
 	}
 
-	[RelayCommand]
+	[RelayCommand(CanExecute = nameof(CanDelete))]
 	private async Task Delete()
 	{
 		if (_project.IsNullOrNew())

--- a/10.0/Apps/DeveloperBalance/Pages/ProjectDetailPage.xaml
+++ b/10.0/Apps/DeveloperBalance/Pages/ProjectDetailPage.xaml
@@ -56,6 +56,7 @@
 
     <ContentPage.ToolbarItems>
         <ToolbarItem
+            Text="Delete"
             Command="{Binding DeleteCommand}"
             Order="Primary"
             Priority="0"

--- a/9.0/Apps/DeveloperBalance/PageModels/ProjectDetailPageModel.cs
+++ b/9.0/Apps/DeveloperBalance/PageModels/ProjectDetailPageModel.cs
@@ -56,7 +56,19 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 		new IconData { Icon = FluentUI.bot_24_regular, Description = "Bot Icon" }
 	};
 
-	public bool HasCompletedTasks
+	private bool _canDelete;
+
+	public bool CanDelete
+	{
+		get => _canDelete;
+		set
+		{
+			_canDelete = value;
+			DeleteCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    public bool HasCompletedTasks
 		=> _project?.Tasks.Any(t => t.IsCompleted) ?? false;
 
 	public ProjectDetailPageModel(ProjectRepository projectRepository, TaskRepository taskRepository, CategoryRepository categoryRepository, TagRepository tagRepository, ModalErrorHandler errorHandler)
@@ -153,7 +165,8 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 		finally
 		{
 			IsBusy = false;
-			OnPropertyChanged(nameof(HasCompletedTasks));
+			CanDelete = !_project.IsNullOrNew();
+            OnPropertyChanged(nameof(HasCompletedTasks));
 		}
 	}
 
@@ -221,7 +234,7 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 			});
 	}
 
-	[RelayCommand]
+	[RelayCommand(CanExecute = nameof(CanDelete))]
 	private async Task Delete()
 	{
 		if (_project.IsNullOrNew())


### PR DESCRIPTION
### Issue Detail
The Delete button was always visible when creating a new project or opening an existing project.  

### Description of Change
Updated the Delete button logic so that it is enabled only when opening an existing project and disabled when creating a new project.

Issues Fixed
Fixes https://github.com/dotnet/maui/issues/30828

### Screenshots

| Before | After |
|----------|----------|
| <img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/a83fb8b2-283a-4028-8f10-3e17e933425d"> | <img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/908cca2c-353f-46e5-8114-5d05bd862d25"> |