### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Official samples can be accessed via the [Samples browser](https://docs.microsof
 Sample highlights include:
 
 * [.NET eShop Reference Application - "Northern Mountains"](https://github.com/dotnet/eShop)
-* [Point of Sale](8.0/Apps/PointOfSale)
-* [Weather '21 App](8.0/Apps/WeatherTwentyOne)
-* [Calculator App](8.0/Apps/Calculator)
+* [Point of Sale](10.0/Apps/PointOfSale)
+* [Weather '21 App](10.0/Apps/WeatherTwentyOne)
+* [Calculator App](10.0/Apps/Calculator)
 * [.NET Podcasts App](https://github.com/microsoft/dotnet-podcasts)
-* [Navigation Samples](8.0/Navigation)
-* [Beginner's Series Task App Sample](8.0/Beginners-Series)
+* [Navigation Samples](10.0/Navigation)
+* [Beginner's Series Task App Sample](10.0/Beginners-Series)
 
 ## Community Samples
 
@@ -42,3 +42,4 @@ This project has adopted the code of conduct defined by the [Contributor Covenan
 ## License
 
 .NET (including the maui-samples repo) is licensed under the [MIT](LICENSE) license.
+


### PR DESCRIPTION
The path for sample highlights was still pointing to 8.0 which was leading to a 404. Now it points to 10.0 and the links are working fine.