### PR TITLE
Fix Selected Tags Not Restored on MainPage After Navigation

### DIFF
--- a/10.0/Apps/DeveloperBalance/PageModels/ProjectDetailPageModel.cs
+++ b/10.0/Apps/DeveloperBalance/PageModels/ProjectDetailPageModel.cs
@@ -321,6 +321,8 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 					await _tagRepository.DeleteItemAsync(tag, _project.ID);
 				}
 			}
+
+			SelectedTags = new List<object>(currentSelection);
 		}
 	}
 }

--- a/10.0/Apps/DeveloperBalance/PageModels/ProjectDetailPageModel.cs
+++ b/10.0/Apps/DeveloperBalance/PageModels/ProjectDetailPageModel.cs
@@ -293,7 +293,7 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 		OnPropertyChanged(nameof(HasCompletedTasks));
 		await AppShell.DisplayToastAsync("All cleaned up!");
 	}
-	
+
 	[RelayCommand]
 	private async Task SelectionChanged(object parameter)
 	{

--- a/10.0/Apps/DeveloperBalance/PageModels/ProjectDetailPageModel.cs
+++ b/10.0/Apps/DeveloperBalance/PageModels/ProjectDetailPageModel.cs
@@ -308,4 +308,34 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 				await ToggleTag(changed[0]);
 		}
 	}
+	
+	[RelayCommand]
+	private async Task TagSelectionChanged(object parameter)
+	{
+		if (parameter is IEnumerable<object> enumerableParameter)
+		{
+			var currentSelection = enumerableParameter.OfType<Tag>().ToList();
+			var previousSelection = AllTags.Where(t => t.IsSelected).ToList();
+
+			// Handle newly selected tags
+			foreach (var tag in currentSelection.Except(previousSelection))
+			{
+				tag.IsSelected = true;
+				if (!_project.IsNullOrNew())
+				{
+					await _tagRepository.SaveItemAsync(tag, _project.ID);
+				}
+			}
+
+			// Handle deselected tags
+			foreach (var tag in previousSelection.Except(currentSelection))
+			{
+				tag.IsSelected = false;
+				if (!_project.IsNullOrNew())
+				{
+					await _tagRepository.DeleteItemAsync(tag, _project.ID);
+				}
+			}
+		}
+	}
 }

--- a/10.0/Apps/DeveloperBalance/PageModels/ProjectDetailPageModel.cs
+++ b/10.0/Apps/DeveloperBalance/PageModels/ProjectDetailPageModel.cs
@@ -293,24 +293,9 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 		OnPropertyChanged(nameof(HasCompletedTasks));
 		await AppShell.DisplayToastAsync("All cleaned up!");
 	}
-
-	[RelayCommand]
-	private async Task SelectionChanged(object parameter)
-	{
-		if (parameter is IEnumerable<object> enumerableParameter)
-		{
-			var changed = enumerableParameter.OfType<Tag>().ToList();
-
-			if (changed.Count == 0 && SelectedTags is not null)
-				changed = SelectedTags.OfType<Tag>().Except(enumerableParameter.OfType<Tag>()).ToList();
-
-			if (changed.Count == 1)
-				await ToggleTag(changed[0]);
-		}
-	}
 	
 	[RelayCommand]
-	private async Task TagSelectionChanged(object parameter)
+	private async Task SelectionChanged(object parameter)
 	{
 		if (parameter is IEnumerable<object> enumerableParameter)
 		{

--- a/10.0/Apps/DeveloperBalance/Pages/ProjectDetailPage.xaml
+++ b/10.0/Apps/DeveloperBalance/Pages/ProjectDetailPage.xaml
@@ -108,7 +108,7 @@
                     HeightRequest="44"
                     Margin="0,0,0,15"
                     SelectedItems="{Binding SelectedTags, Mode=TwoWay}"
-                    SelectionChangedCommand="{Binding SelectionChangedCommand}"
+                    SelectionChangedCommand="{Binding TagSelectionChangedCommand}"
                     SelectionChangedCommandParameter="{Binding SelectedTags}"
                     SemanticProperties.Description="Tags Collection">
                     <CollectionView.ItemsLayout>

--- a/10.0/Apps/DeveloperBalance/Pages/ProjectDetailPage.xaml
+++ b/10.0/Apps/DeveloperBalance/Pages/ProjectDetailPage.xaml
@@ -108,7 +108,7 @@
                     HeightRequest="44"
                     Margin="0,0,0,15"
                     SelectedItems="{Binding SelectedTags, Mode=TwoWay}"
-                    SelectionChangedCommand="{Binding TagSelectionChangedCommand}"
+                    SelectionChangedCommand="{Binding SelectionChangedCommand}"
                     SelectionChangedCommandParameter="{Binding SelectedTags}"
                     SemanticProperties.Description="Tags Collection">
                     <CollectionView.ItemsLayout>

--- a/9.0/Apps/DeveloperBalance/PageModels/ProjectDetailPageModel.cs
+++ b/9.0/Apps/DeveloperBalance/PageModels/ProjectDetailPageModel.cs
@@ -321,6 +321,8 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 					await _tagRepository.DeleteItemAsync(tag, _project.ID);
 				}
 			}
+
+			SelectedTags = new List<object>(currentSelection);
 		}
 	}
 }

--- a/9.0/Apps/DeveloperBalance/PageModels/ProjectDetailPageModel.cs
+++ b/9.0/Apps/DeveloperBalance/PageModels/ProjectDetailPageModel.cs
@@ -299,13 +299,28 @@ public partial class ProjectDetailPageModel : ObservableObject, IQueryAttributab
 	{
 		if (parameter is IEnumerable<object> enumerableParameter)
 		{
-			var changed = enumerableParameter.OfType<Tag>().ToList();
+			var currentSelection = enumerableParameter.OfType<Tag>().ToList();
+			var previousSelection = AllTags.Where(t => t.IsSelected).ToList();
 
-			if (changed.Count == 0 && SelectedTags is not null)
-				changed = SelectedTags.OfType<Tag>().Except(enumerableParameter.OfType<Tag>()).ToList();
+			// Handle newly selected tags
+			foreach (var tag in currentSelection.Except(previousSelection))
+			{
+				tag.IsSelected = true;
+				if (!_project.IsNullOrNew())
+				{
+					await _tagRepository.SaveItemAsync(tag, _project.ID);
+				}
+			}
 
-			if (changed.Count == 1)
-				await ToggleTag(changed[0]);
+			// Handle deselected tags
+			foreach (var tag in previousSelection.Except(currentSelection))
+			{
+				tag.IsSelected = false;
+				if (!_project.IsNullOrNew())
+				{
+					await _tagRepository.DeleteItemAsync(tag, _project.ID);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Issue Detail
Selected tags are not restored on MainPage after returning from ProjectDetailPage.

### Root Cause
After the changes introduced in [PR-611](https://github.com/dotnet/maui-samples/pull/611), when a tag was initially selected, navigating to ProjectDetailPage caused it to be deleted in the [ToggleTag](https://github.com/dotnet/maui-samples/blob/main/9.0/Apps/DeveloperBalance/PageModels/ProjectDetailPageModel.cs#L256) method through the [SelectionChanged](https://github.com/dotnet/maui-samples/blob/main/9.0/Apps/DeveloperBalance/PageModels/ProjectDetailPageModel.cs#L298)  logic. This incorrect logic resulted in the selected tags being lost on the MainPage.

### Description of Change
Updated SelectionChanged command logic that compares the current selection with the previous one, updates the IsSelected property for newly selected or deselected tags, and saves the changes to keep the selection state consistent across navigation.
 
**Breaking changes:** https://github.com/dotnet/maui-samples/pull/611/files#diff-cbae54bfccffc3323ca041b37c3e9be2c5515d8aa51ced752b277d5744eb3591
 
**Break PR:** https://github.com/dotnet/maui-samples/pull/611

### Screenshots

| Before Issue Fix | After Issue Fix |
|----------|----------|
| <video width="300" height="600"  src="https://github.com/user-attachments/assets/27fb3d47-731d-4999-b404-9d6a79ebad9c"> | <video width="300" height="600"  src="https://github.com/user-attachments/assets/9760d559-2972-474c-9952-8d54ecd280eb">) |